### PR TITLE
export relevant names (to create a user-defined env)

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,4 +1,4 @@
-export get_agent_view
+export get_agent_view, AbstractGridWorld
 abstract type AbstractGridWorld end
 
 function get_agent_view end

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,3 +1,5 @@
+export GridWorldBase
+
 using MacroTools:@forward
 using Random
 

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,4 +1,6 @@
-export MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, LRUD, WALL
+export COLORS, MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, UP, DOWN, LEFT, RIGHT, LRUD, EMPTY, WALL, GOAL
+export MoveForward, AbstractObject, Empty, Wall, Goal, Door, Agent
+export get_color
 
 using Crayons
 using Colors


### PR DESCRIPTION
I am exporting certain names like `AbstractGridWorld`, `AbstractObject` etc.. that are required for the creation of a user-defined environment