### PR TITLE
Add agent layer in world BitArray

### DIFF
--- a/src/envs/empty.jl
+++ b/src/envs/empty.jl
@@ -1,27 +1,40 @@
 export EmptyGridWorld
 
 mutable struct EmptyGridWorld <: AbstractGridWorld
-    world::GridWorldBase{Tuple{Empty,Wall,Goal}}
+    world::GridWorldBase{Tuple{Agent, Empty, Wall, Goal}}
     agent_pos::CartesianIndex{2}
     agent::Agent
 end
 
 function EmptyGridWorld(;n=8, agent_start_pos=CartesianIndex(2,2), agent_start_dir=RIGHT)
-    objects = (EMPTY, WALL, GOAL)
+    agent = Agent(dir=agent_start_dir)
+    objects = (agent, EMPTY, WALL, GOAL)
     w = GridWorldBase(objects, n, n)
+
     w[EMPTY, 2:n-1, 2:n-1] .= true
     w[WALL, [1,n], 1:n] .= true
     w[WALL, 1:n, [1,n]] .= true
+
+    w[agent, agent_start_pos] = true
+    w[EMPTY, agent_start_pos] = false
+
     w[GOAL, n-1, n-1] = true
     w[EMPTY, n-1, n-1] = false
-    EmptyGridWorld(w, agent_start_pos, Agent(dir=agent_start_dir))
+
+    EmptyGridWorld(w, agent_start_pos, agent)
 end
 
 function (w::EmptyGridWorld)(::MoveForward)
     dir = get_dir(w.agent)
     dest = dir(w.agent_pos)
     if !w.world[WALL, dest]
+        w.world[w.agent, w.agent_pos] = false
+        if !any(w.world[:, w.agent_pos])
+            w.world[EMPTY, w.agent_pos] = true
+        end
         w.agent_pos = dest
+        w.world[w.agent, w.agent_pos] = true
+        w.world[EMPTY, w.agent_pos] = false
     end
     w
 end


### PR DESCRIPTION
`Agent <: AbstractObject`. So it makes sense to treat it like other objects and add a layer corresponding to it for representing the agent in the world BitArray representation. This will also simplify the code for terminal rendering in [this](https://github.com/JuliaReinforcementLearning/GridWorlds.jl/blob/b0a2d7430d8beeac42ed198949e48a1bfc0897af/src/render_in_terminal.jl#L15) part. Also, we can apply convolutional algorithms directly on the `BitArray` representation of the world, where the learning algorithm need not be given the exact coordinates of the agent explicitly.