### PR TITLE
simplify & standardize makie rendering of objects

### DIFF
--- a/src/render_with_Makie.jl
+++ b/src/render_with_Makie.jl
@@ -23,13 +23,7 @@ function init_screen(w::Observable{<:AbstractGridWorld}; resolution=(1000,1000))
 
     # 2. paint each kind of object
     for o in get_object(w[])
-        if o === WALL
-            poly!(scene, @lift(boxes(findall($w.world[WALL, :, :]), $tile_size)), color=:darkgray,)
-        elseif o === GOAL
-            scatter!(scene, @lift(centers(findall($w.world[GOAL,:,:]), $tile_size)), color=get_color(GOAL), marker=convert(Char, GOAL), markersize=@lift(minimum($tile_size)))
-        elseif o isa Door
-            scatter!(scene, @lift(centers(findall($w.world[o,:,:]), $tile_size)), color=get_color(o), marker=convert(Char, o), markersize=@lift(minimum($tile_size)))
-        elseif o isa Key
+        if o !== EMPTY
             scatter!(scene, @lift(centers(findall($w.world[o,:,:]), $tile_size)), color=get_color(o), marker=convert(Char, o), markersize=@lift(minimum($tile_size)))
         end
     end


### PR DESCRIPTION
This pull request is to simplify the `Makie` rendering process for objects. Instead of manually dispatching each object type (apart from `Agent`) using `if` statements and rendering it separately, this branch implements a default consistent rendering for an object (based on its character representation, as is done previously).

A change that occurs with respect to the previous rendering is that walls are now `:white` (implied by its `get_color` method), as opposed to being `:darkgray` earlier. Note that this default implementation can be easily overridden by explicitly checking for a particular object type. For example, in this case, we could add an `if` statement to check for a `Wall` and manually set the color to `:darkgray`. However, I feel that `:white` doesn't look too bad (in my humble opinion :smile: )

Overall, I believe this buys us a cleaner code and a consistent rendering across Makie and the terminal.

![Screenshot from 2020-10-08 21-01-25](https://user-images.githubusercontent.com/32610387/95480492-96db2780-09a9-11eb-9faa-6147e8d6b200.png)
![Screenshot from 2020-10-08 21-00-53](https://user-images.githubusercontent.com/32610387/95480502-99d61800-09a9-11eb-962f-ad82fe3ea7d0.png)





