### PR TITLE
Refactor

### DIFF
--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -5,6 +5,8 @@ using Requires
 const GW = GridWorlds
 export GW
 
+include("directions.jl")
+include("actions.jl")
 include("objects.jl")
 include("grid_world_base.jl")
 include("abstract_grid_world.jl")

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -1,0 +1,24 @@
+export MoveForward, TurnLeft, TurnRight
+export MOVE_FORWARD, TURN_LEFT, TURN_RIGHT
+
+#####
+# Actions
+#####
+
+struct MoveForward end
+const MOVE_FORWARD = MoveForward()
+
+struct TurnRight end
+const TURN_RIGHT = TurnRight()
+
+struct TurnLeft end
+const TURN_LEFT = TurnLeft()
+
+(x::TurnRight)(::Left) = UP
+(x::TurnRight)(::Up) = RIGHT
+(x::TurnRight)(::Right) = DOWN
+(x::TurnRight)(::Down) = LEFT
+(x::TurnLeft)(::Left) = DOWN
+(x::TurnLeft)(::Up) = LEFT
+(x::TurnLeft)(::Right) = UP
+(x::TurnLeft)(::Down) = RIGHT

--- a/src/directions.jl
+++ b/src/directions.jl
@@ -1,0 +1,24 @@
+export Up, Down, Left, Right
+export UP, DOWN, LEFT, RIGHT, LRUD
+
+#####
+# Directions
+#####
+
+struct Up end
+const UP = Up()
+(x::Up)(p::CartesianIndex{2}) = p + CartesianIndex(-1, 0)
+
+struct Down end
+const DOWN = Down()
+(x::Down)(p::CartesianIndex{2}) = p + CartesianIndex(1, 0)
+
+struct Left end
+const LEFT = Left()
+(x::Left)(p::CartesianIndex{2}) = p + CartesianIndex(0, -1)
+
+struct Right end
+const RIGHT = Right()
+(x::Right)(p::CartesianIndex{2}) = p + CartesianIndex(0, 1)
+
+const LRUD = Union{Left, Right, Up, Down}

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,50 +1,11 @@
-export COLORS, MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, UP, DOWN, LEFT, RIGHT, LRUD, EMPTY, WALL, GOAL, GEM
-export MoveForward, AbstractObject, Empty, Wall, Goal, Door, Gem, Agent
-export get_color
+export COLORS, EMPTY, WALL, GOAL, GEM
+export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Agent
+export get_color, get_dir, set_dir!
 
 using Crayons
 using Colors
 
 const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
-
-#####
-# Actions
-#####
-
-struct MoveForward end
-const MOVE_FORWARD = MoveForward()
-
-struct Up end
-const UP = Up()
-(x::Up)(p::CartesianIndex{2}) = p + CartesianIndex(-1, 0)
-
-struct Down end
-const DOWN = Down()
-(x::Down)(p::CartesianIndex{2}) = p + CartesianIndex(1, 0)
-
-struct Left end
-const LEFT = Left()
-(x::Left)(p::CartesianIndex{2}) = p + CartesianIndex(0, -1)
-
-struct Right end
-const RIGHT = Right()
-(x::Right)(p::CartesianIndex{2}) = p + CartesianIndex(0, 1)
-
-const LRUD = Union{Left, Right, Up, Down}
-
-struct TurnRight end
-const TURN_RIGHT = TurnRight()
-struct TurnLeft end
-const TURN_LEFT = TurnLeft()
-
-(x::TurnRight)(::Left) = UP
-(x::TurnRight)(::Up) = RIGHT
-(x::TurnRight)(::Right) = DOWN
-(x::TurnRight)(::Down) = LEFT
-(x::TurnLeft)(::Left) = DOWN
-(x::TurnLeft)(::Up) = LEFT
-(x::TurnLeft)(::Right) = UP
-(x::TurnLeft)(::Down) = RIGHT
 
 #####
 # Objects
@@ -88,6 +49,7 @@ Base.@kwdef mutable struct Agent <: AbstractObject
     color::Symbol=:red
     dir::LRUD
 end
+
 function Base.convert(::Type{Char}, a::Agent)
     if        a.dir === UP
         '↑'
@@ -99,6 +61,7 @@ function Base.convert(::Type{Char}, a::Agent)
         '→'
     end
 end
+
 get_color(a::Agent) = a.color
 get_dir(a::Agent) = a.dir
 set_dir!(a::Agent, d) = a.dir = d


### PR DESCRIPTION
Refactoring out directions and actions from `objects.jl` into their own respective files.  `objects.jl` should be kept only for defining objects.

Also exported the relevant names.