### PR TITLE
Add support for actions

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,4 +1,5 @@
 export get_agent_view, AbstractGridWorld
+export get_actions
 abstract type AbstractGridWorld end
 
 function get_agent_view end
@@ -21,9 +22,9 @@ function get_agent_view(w::AbstractGridWorld, agent_view_size=(7,7))
     get_agent_view!(v, w)
 end
 
-function (w::AbstractGridWorld)(dir::Union{TurnRight, TurnLeft})
+function (w::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
     a = get_agent(w)
-    set_dir!(a, dir(get_dir(a)))
+    set_dir!(a, action(get_dir(a)))
     w
 end
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -27,6 +27,8 @@ function (w::AbstractGridWorld)(dir::Union{TurnRight, TurnLeft})
     w
 end
 
+get_actions(w::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
+
 get_agent_view_inds(w::AbstractGridWorld, s=(7,7)) = get_agent_view_inds(get_agent_pos(w).I, s, get_agent_dir(w))
 
 get_agent_view!(v::BitArray{3}, w::AbstractGridWorld) = get_agent_view!(v, convert(GridWorldBase, w), get_agent_pos(w), get_agent_dir(w))

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -1,17 +1,19 @@
-export MoveForward, TurnLeft, TurnRight
+export AbstractGridWorldAction, MoveForward, TurnLeft, TurnRight
 export MOVE_FORWARD, TURN_LEFT, TURN_RIGHT
 
 #####
 # Actions
 #####
 
-struct MoveForward end
+abstract type AbstractGridWorldAction end
+
+struct MoveForward <: AbstractGridWorldAction end
 const MOVE_FORWARD = MoveForward()
 
-struct TurnRight end
+struct TurnRight <: AbstractGridWorldAction end
 const TURN_RIGHT = TurnRight()
 
-struct TurnLeft end
+struct TurnLeft <: AbstractGridWorldAction end
 const TURN_LEFT = TurnLeft()
 
 (x::TurnRight)(::Left) = UP


### PR DESCRIPTION
1. Creating an abstract type `AbstractGridWorldAction` for actions.
2. Adding a default implementation for `get_actions` that can be extended by specific environments.
3. Fixed variable name from `dir` to `action` since `TURN_LEFT` and `TURN_RIGHT` are actions.
