### PR TITLE
Add RLBase get_terminal interface to CollectGems

### DIFF
--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -48,3 +48,7 @@ function (w::CollectGems)(::MoveForward)
     end
     w
 end
+
+function get_terminal(w::CollectGems)
+    return w.num_gem_current <= 0
+end


### PR DESCRIPTION
Adding a test file to convert from `GridWorlds` interface to `ReinforcementLearningBase` interface.

Also added a `get_terminal` method for the `CollectGems` environment to test whether the conversion is happening properly for `MaxTimeoutEnv` (see [here](https://github.com/JuliaReinforcementLearning/ReinforcementLearningBase.jl/pull/85)).

This should be helpful in immediately testing an interface of `GridWorlds.jl` (interfaces of `GridWorlds.jl` will be written on the lines of `ReinforcementLearningBase` interface).

This moves us closer to the goal of enhanced connectivity and reusability among packages within `JuliaReinforcementLearning`. In this case, we can easily tap into the awesome functionalities offered by packages like `ReinforcementLearningBase` and `ReinforcementLearningCore` :smile: 