### PR TITLE
add rewards and get_reward capabilities to CollectGems

### DIFF
--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -69,6 +69,4 @@ function get_terminal(w::CollectGems)
     return w.num_gem_current <= 0
 end
 
-function get_reward(w::CollectGems)
-    return w.r
-end
+get_reward(w::CollectGems) = w.r

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -7,7 +7,6 @@ mutable struct CollectGems <: AbstractGridWorld
     num_gem_init::Int
     num_gem_current::Int
     gem_reward::Float64
-    default_reward::Float64
     r::Float64
 end
 
@@ -36,16 +35,15 @@ function CollectGems(;n=8, agent_start_pos=CartesianIndex(2,2), agent_start_dir=
     end
 
     gem_reward = 1.0
-    default_reward = 0.0
-    r = default_reward
+    r = 0.0
 
-    CollectGems(w, agent_start_pos, Agent(dir=agent_start_dir), num_gem_init, num_gem_current, gem_reward, default_reward, r)
+    CollectGems(w, agent_start_pos, Agent(dir=agent_start_dir), num_gem_init, num_gem_current, gem_reward, r)
 end
 
 function (w::CollectGems)(::MoveForward)
     dir = get_dir(w.agent)
     dest = dir(w.agent_pos)
-    w.r = w.default_reward
+    w.r = 0.0
     if !w.world[WALL, dest]
         w.agent_pos = dest
         if w.world[GEM, dest]
@@ -59,7 +57,7 @@ function (w::CollectGems)(::MoveForward)
 end
 
 function (w::CollectGems)(action::Union{TurnRight, TurnLeft})
-    w.r = w.default_reward
+    w.r = 0.0
     agent = get_agent(w)
     set_dir!(agent, action(get_dir(agent)))
     w


### PR DESCRIPTION
Added rewards into the `CollectGems` env struct. The field `r` will maintain the step reward received from the immediately previous action.

Overloaded the default method for `TURN_LEFT` and `TURN_RIGHT` actions in order to update the `env.r` field on every action taken.

Not re-implementing a time penalty for each step taken. Can incorporate this feature using [RewardOverriddenEnv](https://github.com/JuliaReinforcementLearning/ReinforcementLearningBase.jl/blob/d2d82b4b0a71d48d5a0820cd2eda3b8db08abf17/src/implementations/environments.jl#L127)