### PR TITLE
Add reset! method to EmptyGridWorld and FourRooms

### DIFF
--- a/src/envs/empty.jl
+++ b/src/envs/empty.jl
@@ -44,3 +44,10 @@ end
 RLBase.get_terminal(w::EmptyGridWorld) = w.world[GOAL, w.agent_pos]
 
 RLBase.get_reward(w::EmptyGridWorld) = w.reward
+
+function RLBase.reset!(w::EmptyGridWorld)
+    w.reward = 0.0
+    w.agent_pos = CartesianIndex(2, 2)
+    w.agent.dir = RIGHT
+    return w
+end

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -48,3 +48,10 @@ end
 RLBase.get_terminal(w::FourRooms) = w.world[GOAL, w.agent_pos]
 
 RLBase.get_reward(w::FourRooms) = w.reward
+
+function RLBase.reset!(w::FourRooms)
+    w.reward = 0.0
+    w.agent_pos = CartesianIndex(2, 2)
+    w.agent.dir = RIGHT
+    return w
+end


### PR DESCRIPTION
Add a `reset!` method to `EmptyGridWorld` and `FourRooms`.

`reset!` makes the agent start from the top left corner facing right, and it also resets the reward to 0.