### PR TITLE
Add StochasticEnv wrapper

### DIFF
--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -13,6 +13,7 @@ include("grid_world_base.jl")
 include("abstract_grid_world.jl")
 include("envs/envs.jl")
 include("render_in_terminal.jl")
+include("wrappers.jl")
 
 function __init__()
     @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("render_with_Makie.jl")

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -1,0 +1,23 @@
+export StochasticEnv
+
+#####
+# StochasticEnv
+#####
+
+mutable struct StochasticEnv{E<:AbstractEnv, R<:AbstractRNG} <: AbstractEnv
+    env::E
+    rng::R
+end
+
+StochasticEnv(env::E; rng::R = MersenneTwister(123)) where {E<:AbstractEnv, R<:AbstractRNG} = StochasticEnv(env, rng)
+
+# partial constructor to allow chaining
+StochasticEnv(;rng::R = MersenneTwister(123)) where {R<:AbstractRNG} = env -> StochasticEnv(env, rng)
+
+function (env::StochasticEnv)(args...; kwargs...)
+    env.env(args...; kwargs...)
+end
+
+for f in vcat(ENV_API, MULTI_AGENT_ENV_API)
+    @eval $f(x::StochasticEnv, args...; kwargs...) = $f(x.env, args...; kwargs...)
+end

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -1,5 +1,7 @@
 export StochasticEnv
 
+using Random
+
 #####
 # StochasticEnv
 #####
@@ -18,6 +20,6 @@ function (env::StochasticEnv)(args...; kwargs...)
     env.env(args...; kwargs...)
 end
 
-for f in vcat(ENV_API, MULTI_AGENT_ENV_API)
-    @eval $f(x::StochasticEnv, args...; kwargs...) = $f(x.env, args...; kwargs...)
+for f in vcat(RLBase.ENV_API, RLBase.MULTI_AGENT_ENV_API)
+    @eval RLBase.$f(x::StochasticEnv, args...; kwargs...) = RLBase.$f(x.env, args...; kwargs...)
 end


### PR DESCRIPTION
This wrapper allows us to convert a minimally written deterministic environment like `EmptyGridWorld`, and add customized stochastic behaviour without having to create a new environment that is mostly similar and only slightly different.

For example, this wrapper can be used to easily add randomized reset behaviour (random agent start position and direction at each call to `reset!`), or make the agent take the intended action only probabilistically (as if it is a drunken agent).