### PR TITLE
Factor out RLBase defaults

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -22,19 +22,25 @@ function get_agent_view(w::AbstractGridWorld, agent_view_size=(7,7))
     get_agent_view!(v, w)
 end
 
-function (w::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
-    a = get_agent(w)
-    set_dir!(a, action(get_dir(a)))
-    w
-end
-
-RLBase.get_actions(w::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
-
-RLBase.get_state(w::AbstractGridWorld, ::RLBase.PartialObservation{Array}, args...) = get_agent_view(w)
-
-RLBase.DefaultStateStyle(w::AbstractGridWorld) = RLBase.PartialObservation{Array}()
-
 get_agent_view_inds(w::AbstractGridWorld, s=(7,7)) = get_agent_view_inds(get_agent_pos(w).I, s, get_agent_dir(w))
 
 get_agent_view!(v::BitArray{3}, w::AbstractGridWorld) = get_agent_view!(v, convert(GridWorldBase, w), get_agent_pos(w), get_agent_dir(w))
 
+#####
+# RLBase defaults
+#####
+
+RLBase.DefaultStateStyle(w::AbstractGridWorld) = RLBase.PartialObservation{Array}()
+
+RLBase.get_state(w::AbstractGridWorld, ::RLBase.PartialObservation{Array}, args...) = get_agent_view(w)
+
+RLBase.get_actions(w::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
+
+RLBase.get_reward(w::AbstractGridWorld) = w.reward
+
+function (w::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
+    w.reward = 0.0
+    agent = get_agent(w)
+    set_dir!(agent, action(get_dir(agent)))
+    w
+end

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -48,16 +48,7 @@ function (w::CollectGems)(::MoveForward)
     w
 end
 
-function (w::CollectGems)(action::Union{TurnRight, TurnLeft})
-    w.reward = 0.0
-    agent = get_agent(w)
-    set_dir!(agent, action(get_dir(agent)))
-    w
-end
-
 RLBase.get_terminal(w::CollectGems) = w.num_gem_current <= 0
-
-RLBase.get_reward(w::CollectGems) = w.reward
 
 function RLBase.reset!(w::CollectGems; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT)
 

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -58,15 +58,6 @@ function (w::DoorKey)(::MoveForward)
     w
 end
 
-function (w::DoorKey)(action::Union{TurnRight, TurnLeft})
-    w.reward = 0.0
-    agent = get_agent(w)
-    set_dir!(agent, action(get_dir(agent)))
-    w
-end
-
-RLBase.get_reward(w::DoorKey) = w.reward
-
 RLBase.get_terminal(w::DoorKey) = w.world[GOAL, w.agent_pos]
 
 function RLBase.reset!(w::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(w.world)[end] - 1, size(w.world)[end] - 1))

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -81,8 +81,6 @@ end
 
 RLBase.get_terminal(w::DynamicObstacles) = iscollision(w) || w.world[GOAL, w.agent_pos]
 
-RLBase.get_reward(w::DynamicObstacles) = w.reward
-
 function RLBase.reset!(w::DynamicObstacles; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(w.world)[end] - 1, size(w.world)[end] - 1))
 
     n = size(w.world)[end]

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -23,7 +23,6 @@ function EmptyGridWorld(;n=8, agent_start_pos=CartesianIndex(2,2), agent_start_d
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 
     return env
-
 end
 
 function (w::EmptyGridWorld)(::MoveForward)
@@ -39,16 +38,7 @@ function (w::EmptyGridWorld)(::MoveForward)
     w
 end
 
-function (w::EmptyGridWorld)(action::Union{TurnRight, TurnLeft})
-    w.reward = 0.0
-    agent = get_agent(w)
-    set_dir!(agent, action(get_dir(agent)))
-    w
-end
-
 RLBase.get_terminal(w::EmptyGridWorld) = w.world[GOAL, w.agent_pos]
-
-RLBase.get_reward(w::EmptyGridWorld) = w.reward
 
 function RLBase.reset!(w::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(w.world)[end] - 1, size(w.world)[end] - 1))
 

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -43,16 +43,7 @@ function (w::FourRooms)(::MoveForward)
     w
 end
 
-function (w::FourRooms)(action::Union{TurnRight, TurnLeft})
-    w.reward = 0.0
-    agent = get_agent(w)
-    set_dir!(agent, action(get_dir(agent)))
-    w
-end
-
 RLBase.get_terminal(w::FourRooms) = w.world[GOAL, w.agent_pos]
-
-RLBase.get_reward(w::FourRooms) = w.reward
 
 function RLBase.reset!(w::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(w.world[end]) - 1, size(w.world)[end] - 1))
     n = size(w.world)[end]

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -49,16 +49,7 @@ function (w::GoToDoor)(::MoveForward)
     w
 end
 
-function (w::GoToDoor)(action::Union{TurnRight, TurnLeft})
-    w.reward = 0.0
-    agent = get_agent(w)
-    set_dir!(agent, action(get_dir(agent)))
-    w
-end
-
 RLBase.get_state(w::GoToDoor) = (get_agent_view(w), w.target)
-
-RLBase.get_reward(w::GoToDoor) = w.reward
 
 RLBase.get_terminal(w::GoToDoor) = any([w.world[x, w.agent_pos] for x in w.world.objects[end-3:end]])
 


### PR DESCRIPTION
Create generic methods for `RLBase` API written for `AbstractGridWorld`.
Most of these default implementations can be reused in several environments.