### PR TITLE
Cleanup naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ A `GridWorldBase` is used to represent the whole grid world. Inside of it, a 3-D
 ```julia
 using GridWorlds
 
-w = EmptyGridWorld()
+env = EmptyGridWorld()
 
-w(MOVE_FORWARD)
-w(TURN_LEFT)
-w(TURN_RIGHT)
+env(MOVE_FORWARD)
+env(TURN_LEFT)
+env(TURN_RIGHT)
 
 # play interactively with Makie.
 # you need to manually install Makie with the following command first
 # ] add Makie
 # first time plot may be slow
 using Makie
-play(w;file_name="example.gif",frame_rate=5)
+play(env;file_name="example.gif",frame_rate=5)
 ```
 
 ## List of Environments

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -5,42 +5,42 @@ abstract type AbstractGridWorld <: AbstractEnv end
 function get_agent_view end
 function get_agent end
 
-Base.convert(::Type{GridWorldBase}, w::AbstractGridWorld) = w.world
-get_object(w::AbstractGridWorld) = get_object(convert(GridWorldBase, w))
-get_object(w::AbstractGridWorld, x::Type{<:AbstractObject}) = filter(o -> o isa x, get_object(w))
-get_object(w::AbstractGridWorld, x::Type{Agent}) = w.agent
-get_pos(w::AbstractGridWorld, ::Type{Agent}) = w.agent_pos
+Base.convert(::Type{GridWorldBase}, env::AbstractGridWorld) = env.world
+get_object(env::AbstractGridWorld) = get_object(convert(GridWorldBase, env))
+get_object(env::AbstractGridWorld, x::Type{<:AbstractObject}) = filter(o -> o isa x, get_object(env))
+get_object(env::AbstractGridWorld, x::Type{Agent}) = env.agent
+get_pos(env::AbstractGridWorld, ::Type{Agent}) = env.agent_pos
 
-get_agent(w::AbstractGridWorld) = get_object(w, Agent)
-get_agent_pos(w::AbstractGridWorld) = get_pos(w, Agent)
-get_agent_dir(w::AbstractGridWorld) = w |> get_agent |> get_dir
+get_agent(env::AbstractGridWorld) = get_object(env, Agent)
+get_agent_pos(env::AbstractGridWorld) = get_pos(env, Agent)
+get_agent_dir(env::AbstractGridWorld) = env |> get_agent |> get_dir
 
-function get_agent_view(w::AbstractGridWorld, agent_view_size=(7,7))
-    wb = convert(GridWorldBase, w)
-    v = BitArray{3}(undef, size(wb, 1), agent_view_size...)
+function get_agent_view(env::AbstractGridWorld, agent_view_size=(7,7))
+    w = convert(GridWorldBase, env)
+    v = BitArray{3}(undef, size(w, 1), agent_view_size...)
     fill!(v, false)
-    get_agent_view!(v, w)
+    get_agent_view!(v, env)
 end
 
-get_agent_view_inds(w::AbstractGridWorld, s=(7,7)) = get_agent_view_inds(get_agent_pos(w).I, s, get_agent_dir(w))
+get_agent_view_inds(env::AbstractGridWorld, s=(7,7)) = get_agent_view_inds(get_agent_pos(env).I, s, get_agent_dir(env))
 
-get_agent_view!(v::BitArray{3}, w::AbstractGridWorld) = get_agent_view!(v, convert(GridWorldBase, w), get_agent_pos(w), get_agent_dir(w))
+get_agent_view!(v::BitArray{3}, env::AbstractGridWorld) = get_agent_view!(v, convert(GridWorldBase, env), get_agent_pos(env), get_agent_dir(env))
 
 #####
 # RLBase defaults
 #####
 
-RLBase.DefaultStateStyle(w::AbstractGridWorld) = RLBase.PartialObservation{Array}()
+RLBase.DefaultStateStyle(env::AbstractGridWorld) = RLBase.PartialObservation{Array}()
 
-RLBase.get_state(w::AbstractGridWorld, ::RLBase.PartialObservation{Array}, args...) = get_agent_view(w)
+RLBase.get_state(env::AbstractGridWorld, ::RLBase.PartialObservation{Array}, args...) = get_agent_view(env)
 
-RLBase.get_actions(w::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
+RLBase.get_actions(env::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 
-RLBase.get_reward(w::AbstractGridWorld) = w.reward
+RLBase.get_reward(env::AbstractGridWorld) = env.reward
 
-function (w::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
-    w.reward = 0.0
-    agent = get_agent(w)
+function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
+    env.reward = 0.0
+    agent = get_agent(env)
     set_dir!(agent, action(get_dir(agent)))
-    w
+    env
 end

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -32,47 +32,47 @@ function CollectGems(;n=8, agent_start_pos=CartesianIndex(2,2), agent_start_dir=
 
 end
 
-function (w::CollectGems)(::MoveForward)
-    dir = get_dir(w.agent)
-    dest = dir(w.agent_pos)
-    w.reward = 0.0
-    if !w.world[WALL, dest]
-        w.agent_pos = dest
-        if w.world[GEM, dest]
-            w.world[GEM, dest] = false
-            w.world[EMPTY, dest] = true
-            w.num_gem_current = w.num_gem_current - 1
-            w.reward = w.gem_reward
+function (env::CollectGems)(::MoveForward)
+    dir = get_dir(env.agent)
+    dest = dir(env.agent_pos)
+    env.reward = 0.0
+    if !env.world[WALL, dest]
+        env.agent_pos = dest
+        if env.world[GEM, dest]
+            env.world[GEM, dest] = false
+            env.world[EMPTY, dest] = true
+            env.num_gem_current = env.num_gem_current - 1
+            env.reward = env.gem_reward
         end
     end
-    w
+    env
 end
 
-RLBase.get_terminal(w::CollectGems) = w.num_gem_current <= 0
+RLBase.get_terminal(env::CollectGems) = env.num_gem_current <= 0
 
-function RLBase.reset!(w::CollectGems; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT)
+function RLBase.reset!(env::CollectGems; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT)
 
-    n = size(w.world)[end]
-    w.world[EMPTY, 2:n-1, 2:n-1] .= true
-    w.world[GEM, 1:n, 1:n] .= false
-    w.num_gem_current = w.num_gem_init
+    n = size(env.world)[end]
+    env.world[EMPTY, 2:n-1, 2:n-1] .= true
+    env.world[GEM, 1:n, 1:n] .= false
+    env.num_gem_current = env.num_gem_init
 
-    w.reward = 0.0
-    w.agent_pos = agent_start_pos
-    agent = get_agent(w)
+    env.reward = 0.0
+    env.agent_pos = agent_start_pos
+    agent = get_agent(env)
     set_dir!(agent, agent_start_dir)
 
     gem_placed = 0
-    while gem_placed < w.num_gem_init
-        gem_pos = CartesianIndex(rand(w.rng, 2:n-1), rand(w.rng, 2:n-1))
-        if (gem_pos == w.agent_pos) || (w.world[GEM, gem_pos] == true)
+    while gem_placed < env.num_gem_init
+        gem_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 2:n-1))
+        if (gem_pos == env.agent_pos) || (env.world[GEM, gem_pos] == true)
             continue
         else
-            w.world[GEM, gem_pos] = true
-            w.world[EMPTY, gem_pos] = false
+            env.world[GEM, gem_pos] = true
+            env.world[EMPTY, gem_pos] = false
             gem_placed = gem_placed + 1
         end
     end
 
-    return w
+    return env
 end

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -31,56 +31,56 @@ function DoorKey(;n = 7, agent_start_pos = CartesianIndex(2,2), agent_start_dir 
     return env
 end
 
-function (w::DoorKey)(::MoveForward)
-    w.reward = 0.0
-    door = w.world.objects[end - 1]
-    key = w.world.objects[end]
-    dir = get_dir(w.agent)
-    dest = dir(w.agent_pos)
+function (env::DoorKey)(::MoveForward)
+    env.reward = 0.0
+    door = env.world.objects[end - 1]
+    key = env.world.objects[end]
+    dir = get_dir(env.agent)
+    dest = dir(env.agent_pos)
 
-    if w.world[key, dest]
-        if PICK_UP(w.agent, key)
-            w.world[key, dest] = false
-            w.world[EMPTY, dest] = true
+    if env.world[key, dest]
+        if PICK_UP(env.agent, key)
+            env.world[key, dest] = false
+            env.world[EMPTY, dest] = true
         end
-        w.agent_pos = dest
-    elseif w.world[door, dest] && w.agent.inventory !== key
+        env.agent_pos = dest
+    elseif env.world[door, dest] && env.agent.inventory !== key
         nothing
-    elseif w.world[door, dest] && w.agent.inventory === key
-        w.agent_pos = dest
-    elseif !w.world[WALL,dest]
-        w.agent_pos = dest
-        if w.world[GOAL, w.agent_pos]
-            w.reward = w.goal_reward
+    elseif env.world[door, dest] && env.agent.inventory === key
+        env.agent_pos = dest
+    elseif !env.world[WALL,dest]
+        env.agent_pos = dest
+        if env.world[GOAL, env.agent_pos]
+            env.reward = env.goal_reward
         end
     end
 
-    w
+    env
 end
 
-RLBase.get_terminal(w::DoorKey) = w.world[GOAL, w.agent_pos]
+RLBase.get_terminal(env::DoorKey) = env.world[GOAL, env.agent_pos]
 
-function RLBase.reset!(w::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(w.world)[end] - 1, size(w.world)[end] - 1))
-    n = size(w.world)[end]
-    door = w.world.objects[end - 1]
-    key = w.world.objects[end]
-    w.reward = 0.0
-    w.agent_pos = agent_start_pos
-    agent = get_agent(w)
+function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world)[end] - 1, size(env.world)[end] - 1))
+    n = size(env.world)[end]
+    door = env.world.objects[end - 1]
+    key = env.world.objects[end]
+    env.reward = 0.0
+    env.agent_pos = agent_start_pos
+    agent = get_agent(env)
     set_dir!(agent, agent_start_dir)
 
-    door_pos = CartesianIndex(rand(w.rng, 2:n-1), rand(w.rng, 3:n-2))
+    door_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 3:n-2))
     @assert agent_start_pos[2] < door_pos[2] "Agent should start on the left side of the door"
     @assert goal_pos[2] > door_pos[2] "Goal should be placed on the right side of the door"
-    w.world[WALL, :, door_pos[2]] .= true
-    w.world[door, door_pos] = true
-    w.world[WALL, door_pos] = false
+    env.world[WALL, :, door_pos[2]] .= true
+    env.world[door, door_pos] = true
+    env.world[WALL, door_pos] = false
 
-    key_pos = CartesianIndex(rand(w.rng, 2:n-1), rand(w.rng, 2:door_pos[2]-1))
+    key_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 2:door_pos[2]-1))
     while key_pos == agent_start_pos
-        key_pos = CartesianIndex(rand(w.rng, 2:n-1), rand(w.rng, 2:door_pos[2]-1))
+        key_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 2:door_pos[2]-1))
     end
-    w.world[key, key_pos] = true
+    env.world[key, key_pos] = true
 
-    w.world[EMPTY, :, :] .= .!(.|((w.world[x, :, :] for x in [WALL, GOAL, door, key])...))
+    env.world[EMPTY, :, :] .= .!(.|((env.world[x, :, :] for x in [WALL, GOAL, door, key])...))
 end

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -25,31 +25,31 @@ function EmptyGridWorld(;n=8, agent_start_pos=CartesianIndex(2,2), agent_start_d
     return env
 end
 
-function (w::EmptyGridWorld)(::MoveForward)
-    dir = get_dir(w.agent)
-    dest = dir(w.agent_pos)
-    w.reward = 0.0
-    if !w.world[WALL, dest]
-        w.agent_pos = dest
-        if w.world[GOAL, w.agent_pos]
-            w.reward = w.goal_reward
+function (env::EmptyGridWorld)(::MoveForward)
+    dir = get_dir(env.agent)
+    dest = dir(env.agent_pos)
+    env.reward = 0.0
+    if !env.world[WALL, dest]
+        env.agent_pos = dest
+        if env.world[GOAL, env.agent_pos]
+            env.reward = env.goal_reward
         end
     end
-    w
+    env
 end
 
-RLBase.get_terminal(w::EmptyGridWorld) = w.world[GOAL, w.agent_pos]
+RLBase.get_terminal(env::EmptyGridWorld) = env.world[GOAL, env.agent_pos]
 
-function RLBase.reset!(w::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(w.world)[end] - 1, size(w.world)[end] - 1))
+function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world)[end] - 1, size(env.world)[end] - 1))
 
-    w.reward = 0.0
-    w.agent_pos = agent_start_pos
-    agent = get_agent(w)
+    env.reward = 0.0
+    env.agent_pos = agent_start_pos
+    agent = get_agent(env)
     set_dir!(agent, agent_start_dir)
 
-    w.world[EMPTY, :, :] .= .!w.world[WALL, :, :]
-    w.world[GOAL, goal_pos] = true
-    w.world[EMPTY, goal_pos] = false
+    env.world[EMPTY, :, :] .= .!env.world[WALL, :, :]
+    env.world[GOAL, goal_pos] = true
+    env.world[EMPTY, goal_pos] = false
 
-    return w
+    return env
 end

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -30,31 +30,31 @@ function FourRooms(;n=9, agent_start_pos=CartesianIndex(2,2), agent_start_dir=RI
     return env
 end
 
-function (w::FourRooms)(::MoveForward)
-    dir = get_dir(w.agent)
-    dest = dir(w.agent_pos)
-    w.reward = 0.0
-    if !w.world[WALL, dest]
-        w.agent_pos = dest
-        if w.world[GOAL, w.agent_pos]
-            w.reward = w.goal_reward
+function (env::FourRooms)(::MoveForward)
+    dir = get_dir(env.agent)
+    dest = dir(env.agent_pos)
+    env.reward = 0.0
+    if !env.world[WALL, dest]
+        env.agent_pos = dest
+        if env.world[GOAL, env.agent_pos]
+            env.reward = env.goal_reward
         end
     end
-    w
+    env
 end
 
-RLBase.get_terminal(w::FourRooms) = w.world[GOAL, w.agent_pos]
+RLBase.get_terminal(env::FourRooms) = env.world[GOAL, env.agent_pos]
 
-function RLBase.reset!(w::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(w.world[end]) - 1, size(w.world)[end] - 1))
-    n = size(w.world)[end]
-    w.reward = 0.0
-    w.agent_pos = agent_start_pos
-    agent = get_agent(w)
+function RLBase.reset!(env::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world[end]) - 1, size(env.world)[end] - 1))
+    n = size(env.world)[end]
+    env.reward = 0.0
+    env.agent_pos = agent_start_pos
+    agent = get_agent(env)
     set_dir!(agent, agent_start_dir)
 
-    w.world[GOAL, :, :] .= false
-    w.world[GOAL, goal_pos] = true
-    w.world[EMPTY, :, :] .= .!w.world[WALL, :, :]
-    w.world[EMPTY, goal_pos] = false
-    return w
+    env.world[GOAL, :, :] .= false
+    env.world[GOAL, goal_pos] = true
+    env.world[EMPTY, :, :] .= .!env.world[WALL, :, :]
+    env.world[EMPTY, goal_pos] = false
+    return env
 end

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -32,52 +32,52 @@ function GoToDoor(;n=8, agent_start_pos=CartesianIndex(2,2), rng=Random.GLOBAL_R
     return env
 end
 
-function (w::GoToDoor)(::MoveForward)
-    w.reward = 0.0
-    dir = get_dir(w.agent)
-    dest = dir(w.agent_pos)
-    if dest ∈ CartesianIndices((size(w.world, 2), size(w.world, 3))) && !w.world[WALL,dest]
-        w.agent_pos = dest
-        if get_terminal(w)
-            if w.world[w.target, w.agent_pos]
-                w.reward = w.target_reward
+function (env::GoToDoor)(::MoveForward)
+    env.reward = 0.0
+    dir = get_dir(env.agent)
+    dest = dir(env.agent_pos)
+    if dest ∈ CartesianIndices((size(env.world, 2), size(env.world, 3))) && !env.world[WALL,dest]
+        env.agent_pos = dest
+        if get_terminal(env)
+            if env.world[env.target, env.agent_pos]
+                env.reward = env.target_reward
             else
-                w.reward = w.penalty
+                env.reward = env.penalty
             end
         end
     end
-    w
+    env
 end
 
-RLBase.get_state(w::GoToDoor) = (get_agent_view(w), w.target)
+RLBase.get_state(env::GoToDoor) = (get_agent_view(env), env.target)
 
-RLBase.get_terminal(w::GoToDoor) = any([w.world[x, w.agent_pos] for x in w.world.objects[end-3:end]])
+RLBase.get_terminal(env::GoToDoor) = any([env.world[x, env.agent_pos] for x in env.world.objects[end-3:end]])
 
-function RLBase.reset!(w::GoToDoor)
-    n = size(w.world)[end]
+function RLBase.reset!(env::GoToDoor)
+    n = size(env.world)[end]
 
-    w.world[WALL, [1,n], 1:n] .= true
-    w.world[WALL, 1:n, [1,n]] .= true
+    env.world[WALL, [1,n], 1:n] .= true
+    env.world[WALL, 1:n, [1,n]] .= true
 
-    doors = w.world.objects[end-3:end]
+    doors = env.world.objects[end-3:end]
     for door in doors
-        w.world[door, :, :] .= false
+        env.world[door, :, :] .= false
     end
 
-    w.target = rand(w.rng, doors)
-    w.reward = 0.0
+    env.target = rand(env.rng, doors)
+    env.reward = 0.0
 
-    door_pos = [CartesianIndex(rand(w.rng, 2:n-1),1),
-                CartesianIndex(rand(w.rng, 2:n-1),n),
-                CartesianIndex(1,rand(w.rng, 2:n-1)),
-                CartesianIndex(n,rand(w.rng, 2:n-1))]
+    door_pos = [CartesianIndex(rand(env.rng, 2:n-1),1),
+                CartesianIndex(rand(env.rng, 2:n-1),n),
+                CartesianIndex(1,rand(env.rng, 2:n-1)),
+                CartesianIndex(n,rand(env.rng, 2:n-1))]
 
-    rp = randperm(w.rng, length(door_pos))
+    rp = randperm(env.rng, length(door_pos))
 
     for (door, pos) in zip(doors, door_pos[rp])
-        w.world[door, pos] = true
-        w.world[WALL, pos] = false
+        env.world[door, pos] = true
+        env.world[WALL, pos] = false
     end
 
-    w
+    env
 end

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -11,19 +11,19 @@ The first dimension uses multi-hot encoding to encode objects in a tile.
 The second and third dimension means the height and width of the grid.
 """
 struct GridWorldBase{O} <: AbstractArray{Bool, 3}
-    world::BitArray{3}
+    grid::BitArray{3}
     objects::O
 end
 
 get_object(w::GridWorldBase) = w.objects
 
 function GridWorldBase(objects::Tuple{Vararg{AbstractObject}}, x::Int, y::Int)
-    world = BitArray{3}(undef, length(objects), x, y)
-    fill!(world, false)
-    GridWorldBase(world, objects)
+    grid = BitArray{3}(undef, length(objects), x, y)
+    fill!(grid, false)
+    GridWorldBase(grid, objects)
 end
 
-@forward GridWorldBase.world Base.size, Base.getindex, Base.setindex!
+@forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
 
 @generated function Base.to_index(::GridWorldBase{O}, x::X) where {X<:AbstractObject, O}
     i = findfirst(X .=== O.parameters)
@@ -31,12 +31,12 @@ end
     :($i)
 end
 
-Base.setindex!(w::GridWorldBase, v::Bool, o::AbstractObject, x::Int, y::Int) = setindex!(w.world, v, Base.to_index(w, o), x, y)
+Base.setindex!(w::GridWorldBase, v::Bool, o::AbstractObject, x::Int, y::Int) = setindex!(w.grid, v, Base.to_index(w, o), x, y)
 Base.setindex!(w::GridWorldBase, v::Bool, o::AbstractObject, i::CartesianIndex{2}) = setindex!(w, v, o, i[1], i[2])
 
-Base.getindex(w::GridWorldBase, o::AbstractObject, x::Int, y::Int) = getindex(w.world, Base.to_index(w, o), x, y)
+Base.getindex(w::GridWorldBase, o::AbstractObject, x::Int, y::Int) = getindex(w.grid, Base.to_index(w, o), x, y)
 Base.getindex(w::GridWorldBase, o::AbstractObject, i::CartesianIndex{2}) = getindex(w, o, i[1], i[2])
-Base.getindex(w::GridWorldBase, o::AbstractObject, x::Colon, y::Colon) = getindex(w.world, Base.to_index(w, o), x, y)
+Base.getindex(w::GridWorldBase, o::AbstractObject, x::Colon, y::Colon) = getindex(w.grid, Base.to_index(w, o), x, y)
 
 #####
 # utils

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -42,11 +42,11 @@ Base.getindex(w::GridWorldBase, o::AbstractObject, x::Colon, y::Colon) = getinde
 # utils
 #####
 
-switch!(world::GridWorldBase, x, src::CartesianIndex{2}, dest::CartesianIndex{2}) = world[x, src], world[x, dest] = world[x, dest], world[x, src]
+switch!(w::GridWorldBase, x, src::CartesianIndex{2}, dest::CartesianIndex{2}) = w[x, src], w[x, dest] = w[x, dest], w[x, src]
 
-function switch!(world::GridWorldBase, src::CartesianIndex{2}, dest::CartesianIndex{2})
-    for x in axes(world, 1)
-        switch!(world, x, src, dest)
+function switch!(w::GridWorldBase, src::CartesianIndex{2}, dest::CartesianIndex{2})
+    for x in axes(w, 1)
+        switch!(w, x, src, dest)
     end
 end
 

--- a/src/render_in_terminal.jl
+++ b/src/render_in_terminal.jl
@@ -1,22 +1,22 @@
 using Crayons
 
-function Base.show(io::IO, ::MIME"text/markdown", gw::AbstractGridWorld)
-    p, d = get_agent_pos(gw), get_agent_dir(gw)
-    w = convert(GridWorldBase, gw)
+function Base.show(io::IO, ::MIME"text/markdown", env::AbstractGridWorld)
+    p, d = get_agent_pos(env), get_agent_dir(env)
+    w = convert(GridWorldBase, env)
 
     println(io, "World:")
     for i in 1:size(w, 2)
         for j in 1:size(w, 3)
-            if CartesianIndex(i, j) ∈ get_agent_view_inds(gw)
+            if CartesianIndex(i, j) ∈ get_agent_view_inds(env)
                 bg = :dark_gray
             else
                 bg = :black
             end
             if i == p[1] && j == p[2]
-                agent = get_agent(gw)
+                agent = get_agent(env)
                 print(io, Crayon(background=bg, foreground=get_color(agent),reset=true), convert(Char, agent))
             else
-                o = get_object(gw)[findfirst(w.world[:, i, j])]
+                o = get_object(env)[findfirst(w.world[:, i, j])]
                 print(io, Crayon(background=bg, foreground=get_color(o),reset=true),  convert(Char, o))
             end
         end
@@ -25,7 +25,7 @@ function Base.show(io::IO, ::MIME"text/markdown", gw::AbstractGridWorld)
     println(io)
 
     println(io, "Agent's view:")
-    v = get_agent_view(gw)
+    v = get_agent_view(env)
     for i in 1:size(v, 2)
         for j in 1:size(v, 3)
             if i == 1 && j == size(v, 3) ÷ 2 + 1
@@ -35,7 +35,7 @@ function Base.show(io::IO, ::MIME"text/markdown", gw::AbstractGridWorld)
                 if isnothing(x)
                     print(io, '_')
                 else
-                    print(io, get_object(gw)[x])
+                    print(io, get_object(env)[x])
                 end
             end
         end

--- a/src/render_in_terminal.jl
+++ b/src/render_in_terminal.jl
@@ -16,7 +16,7 @@ function Base.show(io::IO, ::MIME"text/markdown", env::AbstractGridWorld)
                 agent = get_agent(env)
                 print(io, Crayon(background=bg, foreground=get_color(agent),reset=true), convert(Char, agent))
             else
-                o = get_object(env)[findfirst(w.world[:, i, j])]
+                o = get_object(env)[findfirst(w.grid[:, i, j])]
                 print(io, Crayon(background=bg, foreground=get_color(o),reset=true),  convert(Char, o))
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,14 +13,14 @@ ACTIONS = [TURN_LEFT, TURN_RIGHT, MOVE_FORWARD]
             w = env()
             @test typeof(w.agent_pos) == CartesianIndex{2}
             @test typeof(w.agent.dir) <: LRUD
-            @test size(w.world.world, 1) == length(w.world.objects)
-            @test 1 ≤ w.agent_pos[1] ≤ size(w.world.world, 2)
-            @test 1 ≤ w.agent_pos[2] ≤ size(w.world.world, 3)
+            @test size(w.world.grid, 1) == length(w.world.objects)
+            @test 1 ≤ w.agent_pos[1] ≤ size(w.world.grid, 2)
+            @test 1 ≤ w.agent_pos[2] ≤ size(w.world.grid, 3)
 
             for _=1:1000
                 w = w(rand(ACTIONS))
-                @test 1 ≤ w.agent_pos[1] ≤ size(w.world.world, 2)
-                @test 1 ≤ w.agent_pos[2] ≤ size(w.world.world, 3)
+                @test 1 ≤ w.agent_pos[1] ≤ size(w.world.grid, 2)
+                @test 1 ≤ w.agent_pos[2] ≤ size(w.world.grid, 3)
                 @test w.world[WALL, w.agent_pos] == false
                 view = get_agent_view(w)
                 @test typeof(view) <: BitArray{3}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,58 +8,58 @@ ENVS_RLBASE = [EmptyGridWorld, FourRooms, GoToDoor, DoorKey, CollectGems, Dynami
 ACTIONS = [TURN_LEFT, TURN_RIGHT, MOVE_FORWARD]
 
 @testset "GridWorlds.jl" begin
-    for env in ENVS
-        @testset "$(env)" begin
-            w = env()
-            @test typeof(w.agent_pos) == CartesianIndex{2}
-            @test typeof(w.agent.dir) <: LRUD
-            @test size(w.world.grid, 1) == length(w.world.objects)
-            @test 1 ≤ w.agent_pos[1] ≤ size(w.world.grid, 2)
-            @test 1 ≤ w.agent_pos[2] ≤ size(w.world.grid, 3)
+    for Env in ENVS
+        @testset "$(Env)" begin
+            env = Env()
+            @test typeof(env.agent_pos) == CartesianIndex{2}
+            @test typeof(env.agent.dir) <: LRUD
+            @test size(env.world.grid, 1) == length(env.world.objects)
+            @test 1 ≤ env.agent_pos[1] ≤ size(env.world.grid, 2)
+            @test 1 ≤ env.agent_pos[2] ≤ size(env.world.grid, 3)
 
             for _=1:1000
-                w = w(rand(ACTIONS))
-                @test 1 ≤ w.agent_pos[1] ≤ size(w.world.grid, 2)
-                @test 1 ≤ w.agent_pos[2] ≤ size(w.world.grid, 3)
-                @test w.world[WALL, w.agent_pos] == false
-                view = get_agent_view(w)
+                env = env(rand(ACTIONS))
+                @test 1 ≤ env.agent_pos[1] ≤ size(env.world.grid, 2)
+                @test 1 ≤ env.agent_pos[2] ≤ size(env.world.grid, 3)
+                @test env.world[WALL, env.agent_pos] == false
+                view = get_agent_view(env)
                 @test typeof(view) <: BitArray{3}
-                @test size(view,1) == length(w.world.objects)
+                @test size(view,1) == length(env.world.objects)
                 @test size(view,2) == 7
                 @test size(view,3) == 7
             end
         end
     end
 
-    for env in ENVS_RLBASE
-        @testset "$(env) RLBase API" begin
-            w = env()
+    for Env in ENVS_RLBASE
+        @testset "$(Env) RLBase API" begin
+            env = Env()
 
-            @test get_reward(w) == 0.0
-            @test get_terminal(w) == false
-            if env == GoToDoor
-                @test get_state(w) == (get_agent_view(w), w.target)
+            @test get_reward(env) == 0.0
+            @test get_terminal(env) == false
+            if Env == GoToDoor
+                @test get_state(env) == (get_agent_view(env), env.target)
             else
-                @test get_state(w) == get_agent_view(w)
+                @test get_state(env) == get_agent_view(env)
             end
 
-            π = RandomPolicy(w)
+            π = RandomPolicy(env)
             total_reward = 0.0
 
-            while !get_terminal(w)
-                action = π(w)
-                w(action)
-                total_reward += get_reward(w)
+            while !get_terminal(env)
+                action = π(env)
+                env(action)
+                total_reward += get_reward(env)
             end
 
-            if env == CollectGems
-                @test total_reward == w.num_gem_init * w.gem_reward
-            elseif env == EmptyGridWorld || env == FourRooms || env == DoorKey
-                @test total_reward == w.goal_reward
-            elseif env == GoToDoor
-                @test (total_reward == w.target_reward || total_reward == w.penalty)
-            elseif env == DynamicObstacles
-                @test (total_reward == w.obstacle_reward || total_reward == w.goal_reward)
+            if Env == CollectGems
+                @test total_reward == env.num_gem_init * env.gem_reward
+            elseif Env == EmptyGridWorld || Env == FourRooms || Env == DoorKey
+                @test total_reward == env.goal_reward
+            elseif Env == GoToDoor
+                @test (total_reward == env.target_reward || total_reward == env.penalty)
+            elseif Env == DynamicObstacles
+                @test (total_reward == env.obstacle_reward || total_reward == env.goal_reward)
             end
         end
     end


### PR DESCRIPTION
Clean up naming convention.
Use `env` to represent an instance of `AbstractGridWorld` (instead of `w` or 'gw`) because it represents an environment. This is consistent with the rest of the packages in the ecosystem.