### PR TITLE
Add `get_full_view` and `get_state` for fully observable settings

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -26,6 +26,13 @@ get_agent_view_inds(env::AbstractGridWorld, s=(7,7)) = get_agent_view_inds(get_a
 
 get_agent_view!(v::BitArray{3}, env::AbstractGridWorld) = get_agent_view!(v, convert(GridWorldBase, env), get_agent_pos(env), get_agent_dir(env))
 
+function get_full_view(env::AbstractGridWorld)
+    dims = size(env.world.grid)[2:end]
+    v = falses(1, dims...)
+    v[1, get_agent_pos(env)] = true
+    return cat(v, env.world.grid, dims = 1)
+end
+
 #####
 # RLBase defaults
 #####
@@ -33,6 +40,8 @@ get_agent_view!(v::BitArray{3}, env::AbstractGridWorld) = get_agent_view!(v, con
 RLBase.DefaultStateStyle(env::AbstractGridWorld) = RLBase.PartialObservation{Array}()
 
 RLBase.get_state(env::AbstractGridWorld, ::RLBase.PartialObservation{Array}, args...) = get_agent_view(env)
+
+RLBase.get_state(env::AbstractGridWorld, ::RLBase.Observation{Array}, args...) = get_full_view(env)
 
 RLBase.get_actions(env::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -41,7 +41,7 @@ RLBase.DefaultStateStyle(env::AbstractGridWorld) = RLBase.PartialObservation{Arr
 
 RLBase.get_state(env::AbstractGridWorld, ::RLBase.PartialObservation{Array}, args...) = get_agent_view(env)
 
-RLBase.get_state(env::AbstractGridWorld, ::RLBase.Observation{Array}, args...) = get_full_view(env)
+RLBase.get_state(env::AbstractGridWorld, ::RLBase.Observation{Array}, args...) = (get_full_view(env), get_agent_dir(env))
 
 RLBase.get_actions(env::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -26,10 +26,15 @@ get_agent_view_inds(env::AbstractGridWorld, s=(7,7)) = get_agent_view_inds(get_a
 
 get_agent_view!(v::BitArray{3}, env::AbstractGridWorld) = get_agent_view!(v, convert(GridWorldBase, env), get_agent_pos(env), get_agent_dir(env))
 
-function get_full_view(env::AbstractGridWorld)
-    dims = size(env.world.grid)[2:end]
+function get_agent_layer(grid::BitArray{3}, agent_pos::CartesianIndex{2})
+    dims = size(grid)[2:end]
     v = falses(1, dims...)
-    v[1, get_agent_pos(env)] = true
+    v[1, agent_pos] = true
+    return v
+end
+
+function get_full_view(env::AbstractGridWorld)
+    v = get_agent_layer(env.world.grid, get_agent_pos(env))
     return cat(v, env.world.grid, dims = 1)
 end
 


### PR DESCRIPTION
1. Add `get_agent_layer` method to obtain the `BitArray` containing the agent's position that can be concatenated with the world `BitArray` to obtain the full view.
2. Add `get_full_view` to observe the entire grid, along with the agent layer.
3. Added `get_state` method for fully observable settings. This also requires providing the direction for complete information.