### PR TITLE
Refactor and clean up

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,5 +1,6 @@
 export AbstractGridWorld
-export get_objects, get_world, get_grid, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_full_view
+export get_world, get_grid, get_objects, get_height, get_width, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_agent_view!, get_full_view
+export set_world!, set_agent!, set_agent_pos!, set_agent_dir!, set_reward!
 
 abstract type AbstractGridWorld <: AbstractEnv end
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -4,10 +4,11 @@ export get_objects, get_world, get_grid, get_agent, get_agent_pos, get_agent_dir
 abstract type AbstractGridWorld <: AbstractEnv end
 
 #####
-# useful getter methods
+# useful getter and setter methods
 #####
 
 get_world(env::AbstractGridWorld) = env.world
+set_world!(env::AbstractGridWorld, world::GridWorldBase) = env.world = world
 
 get_grid(env::AbstractGridWorld, ::Val{:full_view}) = env |> get_world |> get_grid
 get_grid(env::AbstractGridWorld, ::Val{:agent_view}) = get_agent_view(env)
@@ -21,14 +22,17 @@ get_width(env::AbstractGridWorld) = size(get_world(env), 3)
 get_agent(env::AbstractGridWorld, ::Val{:full_view}) = env.agent
 get_agent(env::AbstractGridWorld, ::Val{:agent_view}) = Agent(dir = DOWN)
 get_agent(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent(env, Val{view_type}())
+set_agent!(env::AbstractGridWorld, agent::Agent) = env.agent = agent
 
 get_agent_pos(env::AbstractGridWorld, ::Val{:full_view}) = env.agent_pos
 get_agent_pos(env::AbstractGridWorld, ::Val{:agent_view}) = CartesianIndex(1, size(get_grid(env, Val{:agent_view}()), 3) ÷ 2 + 1)
 get_agent_pos(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent_pos(env, Val{view_type}())
+set_agent_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = env.agent_pos = pos
 
 get_agent_dir(env::AbstractGridWorld, ::Val{:full_view}) = env |> get_agent |> get_dir
 get_agent_dir(env::AbstractGridWorld, ::Val{:agent_view}) = DOWN
 get_agent_dir(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent_dir(env, Val{view_type}())
+set_agent_dir!(env::AbstractGridWorld, dir::Direction) = set_dir!(get_agent(env), dir)
 
 function get_agent_view(env::AbstractGridWorld, agent_view_size = (7,7))
     world = get_world(env)
@@ -53,6 +57,8 @@ function get_full_view(env::AbstractGridWorld)
     agent_layer = get_agent_layer(grid, get_agent_pos(env))
     return cat(agent_layer, grid, dims = 1)
 end
+
+set_reward!(env::AbstractGridWorld, reward) = env.reward = reward
 
 #####
 # RLBase API defaults

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,13 +1,7 @@
 export AbstractGridWorld
-export get_object, get_world, get_grid, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_full_view
+export get_objects, get_world, get_grid, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_full_view
 
 abstract type AbstractGridWorld <: AbstractEnv end
-
-Base.convert(::Type{GridWorldBase}, env::AbstractGridWorld) = env.world
-get_object(env::AbstractGridWorld) = get_object(get_world(env))
-get_object(env::AbstractGridWorld, x::Type{<:AbstractObject}) = filter(o -> o isa x, get_object(env))
-get_object(env::AbstractGridWorld, x::Type{Agent}) = env.agent
-get_pos(env::AbstractGridWorld, ::Type{Agent}) = env.agent_pos
 
 #####
 # useful getter methods
@@ -15,9 +9,11 @@ get_pos(env::AbstractGridWorld, ::Type{Agent}) = env.agent_pos
 
 get_world(env::AbstractGridWorld) = env.world
 
-get_grid(env::AbstractGridWorld, ::Val{:full_view}) = get_world(env).grid
+get_grid(env::AbstractGridWorld, ::Val{:full_view}) = env |> get_world |> get_grid
 get_grid(env::AbstractGridWorld, ::Val{:agent_view}) = get_agent_view(env)
 get_grid(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_grid(env, Val{view_type}())
+
+get_objects(env::AbstractGridWorld) = env |> get_world |> get_objects
 
 get_agent(env::AbstractGridWorld, ::Val{:full_view}) = env.agent
 get_agent(env::AbstractGridWorld, ::Val{:agent_view}) = Agent(dir = DOWN)

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -15,6 +15,9 @@ get_grid(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_grid(env,
 
 get_objects(env::AbstractGridWorld) = env |> get_world |> get_objects
 
+get_height(env::AbstractGridWorld) = size(get_world(env), 2)
+get_width(env::AbstractGridWorld) = size(get_world(env), 3)
+
 get_agent(env::AbstractGridWorld, ::Val{:full_view}) = env.agent
 get_agent(env::AbstractGridWorld, ::Val{:agent_view}) = Agent(dir = DOWN)
 get_agent(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent(env, Val{view_type}())

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -4,7 +4,7 @@ export get_object, get_world, get_grid, get_agent, get_agent_pos, get_agent_dir,
 abstract type AbstractGridWorld <: AbstractEnv end
 
 Base.convert(::Type{GridWorldBase}, env::AbstractGridWorld) = env.world
-get_object(env::AbstractGridWorld) = get_object(convert(GridWorldBase, env))
+get_object(env::AbstractGridWorld) = get_object(get_world(env))
 get_object(env::AbstractGridWorld, x::Type{<:AbstractObject}) = filter(o -> o isa x, get_object(env))
 get_object(env::AbstractGridWorld, x::Type{Agent}) = env.agent
 get_pos(env::AbstractGridWorld, ::Type{Agent}) = env.agent_pos
@@ -32,15 +32,15 @@ get_agent_dir(env::AbstractGridWorld, ::Val{:agent_view}) = DOWN
 get_agent_dir(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent_dir(env, Val{view_type}())
 
 function get_agent_view(env::AbstractGridWorld, agent_view_size = (7,7))
-    world = convert(GridWorldBase, env)
-    grid = BitArray{3}(undef, size(world, 1), agent_view_size...)
-    fill!(grid, false)
-    get_agent_view!(grid, env)
+    world = get_world(env)
+    agent_view = BitArray{3}(undef, size(world, 1), agent_view_size...)
+    fill!(agent_view, false)
+    get_agent_view!(agent_view, env)
 end
 
 get_agent_view_inds(env::AbstractGridWorld, agent_view_size = (7,7)) = get_agent_view_inds(get_agent_pos(env).I, agent_view_size, get_agent_dir(env))
 
-get_agent_view!(grid::BitArray{3}, env::AbstractGridWorld) = get_agent_view!(grid, convert(GridWorldBase, env), get_agent_pos(env), get_agent_dir(env))
+get_agent_view!(grid::BitArray{3}, env::AbstractGridWorld) = get_agent_view!(grid, get_world(env), get_agent_pos(env), get_agent_dir(env))
 
 function get_agent_layer(grid::BitArray{3}, agent_pos::CartesianIndex{2})
     dims = size(grid)[2:end]

--- a/src/directions.jl
+++ b/src/directions.jl
@@ -1,5 +1,5 @@
 export Up, Down, Left, Right, Direction
-export UP, DOWN, LEFT, RIGHT, DIRECTIONS, LRUD
+export UP, DOWN, LEFT, RIGHT, DIRECTIONS
 
 struct Up end
 const UP = Up()
@@ -16,9 +16,6 @@ const LEFT = Left()
 struct Right end
 const RIGHT = Right()
 (x::Right)(p::CartesianIndex{2}) = p + CartesianIndex(0, 1)
-
-# TODO: deprecate LRUD
-const LRUD = Union{Left, Right, Up, Down}
 
 const Direction = Union{Up, Down, Left, Right}
 const DIRECTIONS = (UP, DOWN, LEFT, RIGHT)

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -34,18 +34,18 @@ end
 function (env::CollectGems)(::MoveForward)
     world = get_world(env)
 
-    env.reward = 0.0
+    set_reward!(env, 0.0)
 
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
 
     if !world[WALL, dest]
-        env.agent_pos = dest
+        set_agent_pos!(env, dest)
         if world[GEM, dest]
             world[GEM, dest] = false
             world[EMPTY, dest] = true
             env.num_gem_current = env.num_gem_current - 1
-            env.reward = env.gem_reward
+            set_reward!(env, env.gem_reward)
         end
     end
 
@@ -56,18 +56,18 @@ RLBase.get_terminal(env::CollectGems) = env.num_gem_current <= 0
 
 function RLBase.reset!(env::CollectGems; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT)
     world = get_world(env)
+    n = get_width(env)
 
-    n = size(world)[end]
     world[EMPTY, 2:n-1, 2:n-1] .= true
     world[GEM, 1:n, 1:n] .= false
 
     env.num_gem_current = env.num_gem_init
 
-    env.reward = 0.0
+    set_reward!(env, 0.0)
 
-    env.agent_pos = agent_start_pos
+    set_agent_pos!(env, agent_start_pos)
 
-    set_dir!(get_agent(env), agent_start_dir)
+    set_agent_dir!(env, agent_start_dir)
 
     gem_placed = 0
     while gem_placed < env.num_gem_init

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -59,7 +59,7 @@ function (env::DoorKey)(::MoveForward)
         end
     end
 
-    env
+    return env
 end
 
 RLBase.get_terminal(env::DoorKey) = get_world(env)[GOAL, get_agent_pos(env)]

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -33,7 +33,7 @@ end
 
 function (env::DoorKey)(::MoveForward)
     world = get_world(env)
-    objects = get_object(env)
+    objects = get_objects(env)
     agent = get_agent(env)
 
     env.reward = 0.0
@@ -66,7 +66,7 @@ RLBase.get_terminal(env::DoorKey) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world)[end] - 1, size(env.world)[end] - 1))
     world = get_world(env)
-    objects = get_object(env)
+    objects = get_objects(env)
 
     n = size(world)[end]
 

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -11,10 +11,12 @@ mutable struct DoorKey{W<:GridWorldBase, R} <: AbstractGridWorld
     rng::R
 end
 
-function DoorKey(;n = 7, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), rng = Random.GLOBAL_RNG)
+function DoorKey(; n = 7, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), rng = Random.GLOBAL_RNG)
     door = Door(:yellow)
     key = Key(:yellow)
+
     objects = (EMPTY, WALL, GOAL, door, key)
+
     world = GridWorldBase(objects, n, n)
 
     world[WALL, [1,n], 1:n] .= true
@@ -24,7 +26,7 @@ function DoorKey(;n = 7, agent_start_pos = CartesianIndex(2,2), agent_start_dir 
     goal_reward = 1.0
     reward = 0.0
 
-    env = DoorKey(world, agent_start_pos, Agent(;dir = agent_start_dir), goal_reward, reward, rng)
+    env = DoorKey(world, agent_start_pos, Agent(dir = agent_start_dir), goal_reward, reward, rng)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 
@@ -36,10 +38,12 @@ function (env::DoorKey)(::MoveForward)
     objects = get_objects(env)
     agent = get_agent(env)
 
-    env.reward = 0.0
+    set_reward!(env, 0.0)
+
     door = objects[end - 1]
     key = objects[end]
-    dir = get_dir(agent)
+
+    dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
 
     if world[key, dest]
@@ -47,15 +51,15 @@ function (env::DoorKey)(::MoveForward)
             world[key, dest] = false
             world[EMPTY, dest] = true
         end
-        env.agent_pos = dest
+        set_agent_pos!(env, dest)
     elseif world[door, dest] && agent.inventory !== key
         nothing
     elseif world[door, dest] && agent.inventory === key
-        env.agent_pos = dest
+        set_agent_pos!(env, dest)
     elseif !world[WALL,dest]
-        env.agent_pos = dest
-        if world[GOAL, env.agent_pos]
-            env.reward = env.goal_reward
+        set_agent_pos!(env, dest)
+        if world[GOAL, get_agent_pos(env)]
+            set_reward!(env, env.goal_reward)
         end
     end
 
@@ -64,19 +68,19 @@ end
 
 RLBase.get_terminal(env::DoorKey) = get_world(env)[GOAL, get_agent_pos(env)]
 
-function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world)[end] - 1, size(env.world)[end] - 1))
+function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
+    n = get_width(env)
+
     objects = get_objects(env)
-
-    n = size(world)[end]
-
     door = objects[end - 1]
     key = objects[end]
 
-    env.reward = 0.0
+    set_reward!(env, 0.0)
 
-    env.agent_pos = agent_start_pos
-    set_dir!(get_agent(env), agent_start_dir)
+    set_agent_pos!(env, agent_start_pos)
+
+    set_agent_dir!(env, agent_start_dir)
 
     door_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 3:n-2))
     @assert agent_start_pos[2] < door_pos[2] "Agent should start on the left side of the door"

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -66,6 +66,7 @@ RLBase.get_terminal(env::DoorKey) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world)[end] - 1, size(env.world)[end] - 1))
     world = get_world(env)
+    objects = get_object(env)
 
     n = size(world)[end]
 

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -54,8 +54,9 @@ function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 
 
     set_agent_dir!(env, agent_start_dir)
 
-    world[EMPTY, :, :] .= .!world[WALL, :, :]
+    world[GOAL, :, :] .= false
     world[GOAL, goal_pos] = true
+    world[EMPTY, :, :] .= .!world[WALL, :, :]
     world[EMPTY, goal_pos] = false
 
     return env

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -8,17 +8,17 @@ mutable struct EmptyGridWorld <: AbstractGridWorld
     reward::Float64
 end
 
-function EmptyGridWorld(;n=8, agent_start_pos=CartesianIndex(2,2), agent_start_dir=RIGHT, goal_pos = CartesianIndex(n-1, n-1))
+function EmptyGridWorld(;n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1))
     objects = (EMPTY, WALL, GOAL)
-    w = GridWorldBase(objects, n, n)
+    world = GridWorldBase(objects, n, n)
 
-    w[WALL, [1,n], 1:n] .= true
-    w[WALL, 1:n, [1,n]] .= true
+    world[WALL, [1,n], 1:n] .= true
+    world[WALL, 1:n, [1,n]] .= true
 
     goal_reward = 1.0
     reward = 0.0
 
-    env = EmptyGridWorld(w, agent_start_pos, Agent(dir=agent_start_dir), goal_reward, reward)
+    env = EmptyGridWorld(world, agent_start_pos, Agent(dir = agent_start_dir), goal_reward, reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 
@@ -26,30 +26,32 @@ function EmptyGridWorld(;n=8, agent_start_pos=CartesianIndex(2,2), agent_start_d
 end
 
 function (env::EmptyGridWorld)(::MoveForward)
-    dir = get_dir(env.agent)
-    dest = dir(env.agent_pos)
     env.reward = 0.0
-    if !env.world[WALL, dest]
+    world = get_world(env)
+    agent = get_agent(env)
+    dir = get_dir(agent)
+    dest = dir(get_agent_pos(env))
+    if !world[WALL, dest]
         env.agent_pos = dest
-        if env.world[GOAL, env.agent_pos]
+        if world[GOAL, env.agent_pos]
             env.reward = env.goal_reward
         end
     end
-    env
+    return env
 end
 
-RLBase.get_terminal(env::EmptyGridWorld) = env.world[GOAL, env.agent_pos]
+RLBase.get_terminal(env::EmptyGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world)[end] - 1, size(env.world)[end] - 1))
-
     env.reward = 0.0
+    world = get_world(env)
     env.agent_pos = agent_start_pos
     agent = get_agent(env)
     set_dir!(agent, agent_start_dir)
 
-    env.world[EMPTY, :, :] .= .!env.world[WALL, :, :]
-    env.world[GOAL, goal_pos] = true
-    env.world[EMPTY, goal_pos] = false
+    world[EMPTY, :, :] .= .!world[WALL, :, :]
+    world[GOAL, goal_pos] = true
+    world[EMPTY, goal_pos] = false
 
     return env
 end

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -8,7 +8,7 @@ mutable struct FourRooms <: AbstractGridWorld
     reward::Float64
 end
 
-function FourRooms(;n=9, agent_start_pos=CartesianIndex(2,2), agent_start_dir=RIGHT, goal_pos=CartesianIndex(n-1, n-1))
+function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1))
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
 
@@ -23,7 +23,7 @@ function FourRooms(;n=9, agent_start_pos=CartesianIndex(2,2), agent_start_dir=RI
     goal_reward = 1.0
     reward = 0.0
 
-    env = FourRooms(world,agent_start_pos,Agent(dir=RIGHT), goal_reward, reward)
+    env = FourRooms(world, agent_start_pos, Agent(dir = RIGHT), goal_reward, reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 
@@ -31,30 +31,34 @@ function FourRooms(;n=9, agent_start_pos=CartesianIndex(2,2), agent_start_dir=RI
 end
 
 function (env::FourRooms)(::MoveForward)
-    dir = get_dir(env.agent)
-    dest = dir(env.agent_pos)
     env.reward = 0.0
-    if !env.world[WALL, dest]
+    world = get_world(env)
+    agent = get_agent(env)
+    dir = get_dir(agent)
+    dest = dir(get_agent_pos(env))
+    if !world[WALL, dest]
         env.agent_pos = dest
-        if env.world[GOAL, env.agent_pos]
+        if world[GOAL, get_agent_pos(env)]
             env.reward = env.goal_reward
         end
     end
-    env
+    return env
 end
 
-RLBase.get_terminal(env::FourRooms) = env.world[GOAL, env.agent_pos]
+RLBase.get_terminal(env::FourRooms) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world[end]) - 1, size(env.world)[end] - 1))
-    n = size(env.world)[end]
+    world = get_world(env)
+
     env.reward = 0.0
     env.agent_pos = agent_start_pos
     agent = get_agent(env)
     set_dir!(agent, agent_start_dir)
 
-    env.world[GOAL, :, :] .= false
-    env.world[GOAL, goal_pos] = true
-    env.world[EMPTY, :, :] .= .!env.world[WALL, :, :]
-    env.world[EMPTY, goal_pos] = false
+    world[GOAL, :, :] .= false
+    world[GOAL, goal_pos] = true
+    world[EMPTY, :, :] .= .!world[WALL, :, :]
+    world[EMPTY, goal_pos] = false
+
     return env
 end

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -31,29 +31,33 @@ function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2,2), agent_start_d
 end
 
 function (env::FourRooms)(::MoveForward)
-    env.reward = 0.0
     world = get_world(env)
-    agent = get_agent(env)
-    dir = get_dir(agent)
+
+    set_reward!(env, 0.0)
+
+    dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
+
     if !world[WALL, dest]
-        env.agent_pos = dest
+        set_agent_pos!(env, dest)
         if world[GOAL, get_agent_pos(env)]
-            env.reward = env.goal_reward
+            set_reward!(env, env.goal_reward)
         end
     end
+
     return env
 end
 
 RLBase.get_terminal(env::FourRooms) = get_world(env)[GOAL, get_agent_pos(env)]
 
-function RLBase.reset!(env::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(size(env.world[end]) - 1, size(env.world)[end] - 1))
+function RLBase.reset!(env::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
 
-    env.reward = 0.0
-    env.agent_pos = agent_start_pos
-    agent = get_agent(env)
-    set_dir!(agent, agent_start_dir)
+    set_reward!(env, 0.0)
+
+    set_agent_pos!(env, agent_start_pos)
+
+    set_agent_dir!(env, agent_start_dir)
 
     world[GOAL, :, :] .= false
     world[GOAL, goal_pos] = true

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -34,23 +34,23 @@ end
 
 function (env::GoToDoor)(::MoveForward)
     world = get_world(env)
-    agent = get_agent(env)
 
-    env.reward = 0.0
+    set_reward!(env, 0.0)
 
-    dir = get_dir(agent)
+    dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
 
     if dest ∈ CartesianIndices((size(world, 2), size(world, 3))) && !world[WALL,dest]
-        env.agent_pos = dest
+        set_agent_pos!(env, dest)
         if get_terminal(env)
             if world[env.target, get_agent_pos(env)]
-                env.reward = env.target_reward
+                set_reward!(env, env.target_reward)
             else
-                env.reward = env.penalty
+                set_reward!(env, env.penalty)
             end
         end
     end
+
     return env
 end
 
@@ -61,7 +61,7 @@ RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[x, env.agent_pos] for x
 function RLBase.reset!(env::GoToDoor)
     world = get_world(env)
 
-    n = size(world)[end]
+    n = get_width(env)
 
     world[WALL, [1,n], 1:n] .= true
     world[WALL, 1:n, [1,n]] .= true
@@ -72,7 +72,7 @@ function RLBase.reset!(env::GoToDoor)
     end
 
     env.target = rand(env.rng, doors)
-    env.reward = 0.0
+    set_reward!(env, 0.0)
 
     door_pos = [CartesianIndex(rand(env.rng, 2:n-1),1),
                 CartesianIndex(rand(env.rng, 2:n-1),n),

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -56,7 +56,7 @@ end
 
 RLBase.get_state(env::GoToDoor) = (get_agent_view(env), env.target)
 
-RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[x, env.agent_pos] for x in get_object(env)[end-3:end]])
+RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[x, env.agent_pos] for x in get_objects(env)[end-3:end]])
 
 function RLBase.reset!(env::GoToDoor)
     world = get_world(env)
@@ -66,7 +66,7 @@ function RLBase.reset!(env::GoToDoor)
     world[WALL, [1,n], 1:n] .= true
     world[WALL, 1:n, [1,n]] .= true
 
-    doors = get_object(env)[end-3:end]
+    doors = get_objects(env)[end-3:end]
     for door in doors
         world[door, :, :] .= false
     end

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -234,7 +234,7 @@ function get_centered_world(world::GridWorldBase)
     small_n = size(world)[end] ÷ 2
     new_global_origin = get_new_global_origin(world)
     new_global_region = CartesianIndices((new_global_origin.I[1] : new_global_origin.I[1] + small_n - 1, new_global_origin.I[2] : new_global_origin.I[2] + small_n - 1))
-    centered_world = GridWorldBase(get_object(world), small_n, small_n)
+    centered_world = GridWorldBase(get_objects(world), small_n, small_n)
     centered_world[:, :, :] .= world[:, new_global_region]
     return centered_world
 end

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -13,10 +13,10 @@ Room(origin, height, width) = Room(CartesianIndices((origin.I[1] : origin.I[1] +
 get_origin(region::CartesianIndices{2}) = region[1, 1]
 get_origin(room::Room) = get_origin(room.region)
 
-interior(room::Room) = room.region[2:end-1, 2:end-1]
+get_interior(room::Room) = room.region[2:end-1, 2:end-1]
 
 function is_intersecting(room1::Room, room2::Room)
-    intersection = intersect(interior(room1), room2.region)
+    intersection = intersect(get_interior(room1), room2.region)
     length(intersection) > 0 ? true : false
 end
 
@@ -114,13 +114,13 @@ function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)
     set_world!(env, centered_world)
 
     # add the agent randomly in the first room
-    set_agent_pos!(env, rand(env.rng, interior(env.rooms[1])))
+    set_agent_pos!(env, rand(env.rng, get_interior(env.rooms[1])))
 
     # add the GOAL randomly in the last room
     world = get_world(env)
-    goal_pos = rand(env.rng, interior(env.rooms[end]))
+    goal_pos = rand(env.rng, get_interior(env.rooms[end]))
     while goal_pos == env.agent_pos
-        goal_pos = rand(env.rng, interior(env.rooms[end]))
+        goal_pos = rand(env.rng, get_interior(env.rooms[end]))
     end
     world[GOAL, goal_pos] = true
     world[EMPTY, goal_pos] = false
@@ -144,8 +144,8 @@ end
 function add_room!(env::AbstractGridWorld, room::Room)
     world = get_world(env)
     world[WALL, room.region] .= true
-    world[WALL, interior(room)] .= false
-    world[EMPTY, interior(room)] .= true
+    world[WALL, get_interior(room)] .= false
+    world[EMPTY, get_interior(room)] .= true
     push!(env.rooms, room)
 end
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,4 +1,5 @@
 export GridWorldBase
+export get_objects
 
 using MacroTools:@forward
 using Random
@@ -16,7 +17,7 @@ struct GridWorldBase{O} <: AbstractArray{Bool, 3}
 end
 
 get_grid(world::GridWorldBase) = world.grid
-get_object(world::GridWorldBase) = world.objects
+get_objects(world::GridWorldBase) = world.objects
 
 function GridWorldBase(objects::Tuple{Vararg{AbstractObject}}, height::Int, width::Int)
     grid = BitArray{3}(undef, length(objects), height, width)

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -74,7 +74,7 @@ ind_map((i,j), (m, n), ::Right) = (j, n-i+1)
 ind_map((i,j), (m, n), ::Up) = (m-i+1, n-j+1)
 ind_map((i,j), (m, n), ::Down) = (i,j)
 
-function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{Bool,3}, agent_pos::CartesianIndex{2}, dir::LRUD)
+function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{Bool,3}, agent_pos::CartesianIndex{2}, dir::Direction)
     view_size = (size(agent_view, 2), size(agent_view, 3))
     grid_size = (size(grid,2),size(grid,3))
     inds = get_agent_view_inds(agent_pos.I, view_size, dir)

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -31,12 +31,12 @@ end
     :($i)
 end
 
-Base.setindex!(world::GridWorldBase, v::Bool, o::AbstractObject, x::Int, y::Int) = setindex!(world.grid, v, Base.to_index(world, o), x, y)
-Base.setindex!(world::GridWorldBase, v::Bool, o::AbstractObject, i::CartesianIndex{2}) = setindex!(world, v, o, i[1], i[2])
+Base.setindex!(world::GridWorldBase, ispresent::Bool, object::AbstractObject, height::Int, width::Int) = setindex!(world.grid, ispresent, Base.to_index(world, object), height, width)
+Base.setindex!(world::GridWorldBase, ispresent::Bool, object::AbstractObject, pos::CartesianIndex{2}) = setindex!(world, ispresent, object, pos[1], pos[2])
 
-Base.getindex(world::GridWorldBase, o::AbstractObject, x::Int, y::Int) = getindex(world.grid, Base.to_index(world, o), x, y)
-Base.getindex(world::GridWorldBase, o::AbstractObject, i::CartesianIndex{2}) = getindex(world, o, i[1], i[2])
-Base.getindex(world::GridWorldBase, o::AbstractObject, x::Colon, y::Colon) = getindex(world.grid, Base.to_index(world, o), x, y)
+Base.getindex(world::GridWorldBase, object::AbstractObject, height::Int, width::Int) = getindex(world.grid, Base.to_index(world, object), height, width)
+Base.getindex(world::GridWorldBase, object::AbstractObject, pos::CartesianIndex{2}) = getindex(world, object, pos[1], pos[2])
+Base.getindex(world::GridWorldBase, object::AbstractObject, heights::Colon, widths::Colon) = getindex(world.grid, Base.to_index(world, object), heights, widths)
 
 #####
 # utils

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -15,6 +15,7 @@ struct GridWorldBase{O} <: AbstractArray{Bool, 3}
     objects::O
 end
 
+get_grid(world::GridWorldBase) = world.grid
 get_object(world::GridWorldBase) = world.objects
 
 function GridWorldBase(objects::Tuple{Vararg{AbstractObject}}, height::Int, width::Int)

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -15,7 +15,7 @@ struct GridWorldBase{O} <: AbstractArray{Bool, 3}
     objects::O
 end
 
-get_object(w::GridWorldBase) = w.objects
+get_object(world::GridWorldBase) = world.objects
 
 function GridWorldBase(objects::Tuple{Vararg{AbstractObject}}, x::Int, y::Int)
     grid = BitArray{3}(undef, length(objects), x, y)
@@ -31,30 +31,30 @@ end
     :($i)
 end
 
-Base.setindex!(w::GridWorldBase, v::Bool, o::AbstractObject, x::Int, y::Int) = setindex!(w.grid, v, Base.to_index(w, o), x, y)
-Base.setindex!(w::GridWorldBase, v::Bool, o::AbstractObject, i::CartesianIndex{2}) = setindex!(w, v, o, i[1], i[2])
+Base.setindex!(world::GridWorldBase, v::Bool, o::AbstractObject, x::Int, y::Int) = setindex!(world.grid, v, Base.to_index(w, o), x, y)
+Base.setindex!(world::GridWorldBase, v::Bool, o::AbstractObject, i::CartesianIndex{2}) = setindex!(w, v, o, i[1], i[2])
 
-Base.getindex(w::GridWorldBase, o::AbstractObject, x::Int, y::Int) = getindex(w.grid, Base.to_index(w, o), x, y)
-Base.getindex(w::GridWorldBase, o::AbstractObject, i::CartesianIndex{2}) = getindex(w, o, i[1], i[2])
-Base.getindex(w::GridWorldBase, o::AbstractObject, x::Colon, y::Colon) = getindex(w.grid, Base.to_index(w, o), x, y)
+Base.getindex(world::GridWorldBase, o::AbstractObject, x::Int, y::Int) = getindex(world.grid, Base.to_index(w, o), x, y)
+Base.getindex(world::GridWorldBase, o::AbstractObject, i::CartesianIndex{2}) = getindex(w, o, i[1], i[2])
+Base.getindex(world::GridWorldBase, o::AbstractObject, x::Colon, y::Colon) = getindex(world.grid, Base.to_index(w, o), x, y)
 
 #####
 # utils
 #####
 
-switch!(w::GridWorldBase, x, src::CartesianIndex{2}, dest::CartesianIndex{2}) = w[x, src], w[x, dest] = w[x, dest], w[x, src]
+switch!(world::GridWorldBase, x, src::CartesianIndex{2}, dest::CartesianIndex{2}) = world[x, src], world[x, dest] = world[x, dest], world[x, src]
 
-function switch!(w::GridWorldBase, src::CartesianIndex{2}, dest::CartesianIndex{2})
-    for x in axes(w, 1)
-        switch!(w, x, src, dest)
+function switch!(world::GridWorldBase, src::CartesianIndex{2}, dest::CartesianIndex{2})
+    for x in axes(world, 1)
+        switch!(world, x, src, dest)
     end
 end
 
-function Random.rand(f::Function, w::GridWorldBase; max_try=typemax(Int), rng=Random.GLOBAL_RNG)
-    inds = CartesianIndices((size(w, 2), size(w, 3)))
+function Random.rand(f::Function, world::GridWorldBase; max_try=typemax(Int), rng=Random.GLOBAL_RNG)
+    inds = CartesianIndices((size(world, 2), size(world, 3)))
     for _ in 1:max_try
         pos = rand(rng, inds)
-        f(view(w, :, pos)) && return pos
+        f(view(world, :, pos)) && return pos
     end
     @warn "a rare case happened when sampling from GridWorldBase"
     return nothing

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,5 +1,5 @@
 export GridWorldBase
-export get_objects
+export get_grid, get_objects, get_height, get_width, switch!, get_agent_view!
 
 using MacroTools:@forward
 using Random

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -16,14 +16,17 @@ struct GridWorldBase{O} <: AbstractArray{Bool, 3}
     objects::O
 end
 
-get_grid(world::GridWorldBase) = world.grid
-get_objects(world::GridWorldBase) = world.objects
-
 function GridWorldBase(objects::Tuple{Vararg{AbstractObject}}, height::Int, width::Int)
     grid = BitArray{3}(undef, length(objects), height, width)
     fill!(grid, false)
     GridWorldBase(grid, objects)
 end
+
+get_grid(world::GridWorldBase) = world.grid
+get_objects(world::GridWorldBase) = world.objects
+
+get_height(world::GridWorldBase) = size(world, 2)
+get_width(world::GridWorldBase) = size(world, 3)
 
 @forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -74,15 +74,15 @@ ind_map((i,j), (m, n), ::Right) = (j, n-i+1)
 ind_map((i,j), (m, n), ::Up) = (m-i+1, n-j+1)
 ind_map((i,j), (m, n), ::Down) = (i,j)
 
-function get_agent_view!(v::AbstractArray{Bool,3}, a::AbstractArray{Bool,3}, p::CartesianIndex, dir::LRUD)
-    view_size = (size(v, 2), size(v, 3))
-    grid_size = (size(a,2),size(a,3))
-    inds = get_agent_view_inds(p.I, view_size, dir)
+function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{Bool,3}, agent_pos::CartesianIndex{2}, dir::LRUD)
+    view_size = (size(agent_view, 2), size(agent_view, 3))
+    grid_size = (size(grid,2),size(grid,3))
+    inds = get_agent_view_inds(agent_pos.I, view_size, dir)
     valid_inds = CartesianIndices(grid_size)
     for ind in CartesianIndices(inds)
         if inds[ind] ∈ valid_inds
-            v[:, ind_map(ind.I, view_size, dir)...] .= a[:, inds[ind]]
+            agent_view[:, ind_map(ind.I, view_size, dir)...] .= grid[:, inds[ind]]
         end
     end
-    v
+    agent_view
 end

--- a/src/makie_rendering.jl
+++ b/src/makie_rendering.jl
@@ -22,7 +22,7 @@ function init_screen(env::Observable{<:AbstractGridWorld}; resolution=(1000,1000
     poly!(scene, area)
 
     # 2. paint each kind of object
-    for o in get_object(env[])
+    for o in get_objects(env[])
         if o !== EMPTY
             scatter!(scene, @lift(centers(findall($env.world[o,:,:]), $tile_size)), color=get_color(o), marker=convert(Char, o), markersize=@lift(minimum($tile_size)))
         end

--- a/src/makie_rendering.jl
+++ b/src/makie_rendering.jl
@@ -24,7 +24,7 @@ function init_screen(env::Observable{<:AbstractGridWorld}; resolution=(1000,1000
     # 2. paint each kind of object
     for o in get_objects(env[])
         if o !== EMPTY
-            scatter!(scene, @lift(centers(findall($env.world[o,:,:]), $tile_size)), color=get_color(o), marker=convert(Char, o), markersize=@lift(minimum($tile_size)))
+            scatter!(scene, @lift(centers(findall($env.world[o,:,:]), $tile_size)), color=get_color(o), marker=get_char(o), markersize=@lift(minimum($tile_size)))
         end
     end
 
@@ -38,7 +38,7 @@ function init_screen(env::Observable{<:AbstractGridWorld}; resolution=(1000,1000
     # 4. paint agent
     agent = @lift(get_agent($env))
     agent_position = @lift((T(get_agent_pos($env)).I .- (0.5, 0.5)).* $tile_size)
-    scatter!(scene, agent_position, color=@lift(get_color($agent)), marker=@lift(convert(Char, $agent)), markersize=@lift(minimum($tile_size)))
+    scatter!(scene, agent_position, color=@lift(get_color($agent)), marker=@lift(get_char($agent)), markersize=@lift(minimum($tile_size)))
 
     display(scene)
     scene

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -77,8 +77,9 @@ get_dir(agent::Agent) = agent.dir
 set_dir!(agent::Agent, dir) = agent.dir = dir
 
 struct Transportable end
-struct NonTransportable end
 const TRANSPORTABLE = Transportable()
+
+struct NonTransportable end
 const NONTRANSPORTABLE = NonTransportable()
 
 istransportable(::Type{<:AbstractObject}) = NONTRANSPORTABLE

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -56,7 +56,7 @@ get_color(::Obstacle) = :blue
 
 Base.@kwdef mutable struct Agent <: AbstractObject
     color::Symbol=:red
-    dir::LRUD
+    dir::Direction
     inventory::Union{Nothing, AbstractObject, Vector}=nothing
 end
 

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,5 +1,5 @@
-export COLORS, MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, UP, DOWN, LEFT, RIGHT, LRUD, EMPTY, WALL, GOAL, GEM, OBSTACLE
-export MoveForward, AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Agent
+export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE
+export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Agent
 export get_color, get_dir, set_dir!
 
 using Crayons

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -13,41 +13,41 @@ const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
 
 abstract type AbstractObject end
 
-Base.show(io::IO, object::AbstractObject) = print(io, Crayon(foreground = get_color(object), reset = true), convert(Char, object))
+Base.show(io::IO, object::AbstractObject) = print(io, Crayon(foreground = get_color(object), reset = true), get_char(object))
 
 struct Empty <: AbstractObject end
 const EMPTY = Empty()
-Base.convert(::Type{Char}, ::Empty) = '⋅'
+get_char(::Empty) = '⋅'
 get_color(::Empty) = :white
 
 struct Wall <: AbstractObject end
 const WALL = Wall()
-Base.convert(::Type{Char}, ::Wall) = '█'
+get_char(::Wall) = '█'
 get_color(::Wall) = :white
 
 struct Goal <: AbstractObject end
 const GOAL = Goal()
-Base.convert(::Type{Char}, ::Goal) = '♥'
+get_char(::Goal) = '♥'
 get_color(::Goal) = :red
 
 struct Door{C} <: AbstractObject end
 Door(c) = Door{c}()
-Base.convert(::Type{Char}, ::Door) = '⩎'
+get_char(::Door) = '⩎'
 get_color(::Door{C}) where C = C
 
 struct Key{C} <: AbstractObject end
 Key(c) = Key{c}()
-Base.convert(::Type{Char}, ::Key) = '⚷'
+get_char(::Key) = '⚷'
 get_color(::Key{C}) where C = C
 
 struct Gem <: AbstractObject end
 const GEM = Gem()
-Base.convert(::Type{Char}, ::Gem) = '♦'
+get_char(::Gem) = '♦'
 get_color(::Gem) = :magenta
 
 struct Obstacle <: AbstractObject end
 const OBSTACLE = Obstacle()
-Base.convert(::Type{Char}, ::Obstacle) = '⊗'
+get_char(::Obstacle) = '⊗'
 get_color(::Obstacle) = :blue    
 
 #####
@@ -60,14 +60,14 @@ Base.@kwdef mutable struct Agent <: AbstractObject
     inventory::Union{Nothing, AbstractObject, Vector}=nothing
 end
 
-function Base.convert(::Type{Char}, a::Agent)
-    if     a.dir === UP
+function get_char(agent::Agent)
+    if     agent.dir === UP
         '↑'
-    elseif a.dir === DOWN
+    elseif agent.dir === DOWN
         '↓'
-    elseif a.dir === LEFT
+    elseif agent.dir === LEFT
         '←'
-    elseif a.dir === RIGHT
+    elseif agent.dir === RIGHT
         '→'
     end
 end

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -13,7 +13,7 @@ const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
 
 abstract type AbstractObject end
 
-Base.show(io::IO, x::AbstractObject) = print(io, Crayon(foreground=get_color(x), reset=true), convert(Char, x))
+Base.show(io::IO, object::AbstractObject) = print(io, Crayon(foreground = get_color(object), reset = true), convert(Char, object))
 
 struct Empty <: AbstractObject end
 const EMPTY = Empty()
@@ -72,9 +72,9 @@ function Base.convert(::Type{Char}, a::Agent)
     end
 end
 
-get_color(a::Agent) = a.color
-get_dir(a::Agent) = a.dir
-set_dir!(a::Agent, d) = a.dir = d
+get_color(agent::Agent) = agent.color
+get_dir(agent::Agent) = agent.dir
+set_dir!(agent::Agent, dir) = agent.dir = dir
 
 struct Transportable end
 struct NonTransportable end

--- a/src/terminal_rendering.jl
+++ b/src/terminal_rendering.jl
@@ -10,7 +10,7 @@ function print_grid(io::IO, env::AbstractGridWorld, view_type)
     agent_layer = get_agent_layer(grid, agent_pos)
     grid = cat(agent_layer, grid, dims = 1)
 
-    objects = (agent, get_object(env)...)
+    objects = (agent, get_objects(env)...)
 
     for i in 1:size(grid, 2)
         for j in 1:size(grid, 3)

--- a/src/terminal_rendering.jl
+++ b/src/terminal_rendering.jl
@@ -23,7 +23,7 @@ function print_grid(io::IO, env::AbstractGridWorld, view_type)
             else
                 o = objects[idx]
                 foreground = get_color(o)
-                c = convert(Char, o)
+                c = get_char(o)
             end
             print(io, Crayon(background = get_background(env, pos, Val{view_type}()), foreground = foreground, bold = true, reset = true), c)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ ACTIONS = [TURN_LEFT, TURN_RIGHT, MOVE_FORWARD]
         @testset "$(Env)" begin
             env = Env()
             @test typeof(env.agent_pos) == CartesianIndex{2}
-            @test typeof(env.agent.dir) <: LRUD
+            @test typeof(env.agent.dir) <: Direction
             @test size(env.world.grid, 1) == length(env.world.objects)
             @test 1 ≤ env.agent_pos[1] ≤ size(env.world.grid, 2)
             @test 1 ≤ env.agent_pos[2] ≤ size(env.world.grid, 3)


### PR DESCRIPTION
1. Add useful `get_...` and `set_...` methods. These methods are extensively reused throughout the code-base.
2. Use `get_char` instead of `Base.convert` to get character representation. Just like `get_color` is used to get the color of an object, `get_char` is used to get the character representation of an object. The name `get_char` better describes this behavior than the name `convert`.
3. Use `get_world` instead of `Base.convert` (address #81 ) . Reason same as for `get_char`.
4. Clean up exports.
5. Deprecate `LRUD` in favor of `Direction`.
6. Use consistent and informative variable names throughout the code-base.
7. Remove some unused methods.
