### PR TITLE
Refactor and Clean

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -58,12 +58,12 @@ end
 set_reward!(env::AbstractGridWorld, reward) = env.reward = reward
 
 function get_world_with_agent(env::AbstractGridWorld; view_type::Symbol = :full_view)
-    grid = get_grid(env, Val{view_type}())
-    agent_pos = get_agent_pos(env, Val{view_type}())
+    grid = get_grid(env, view_type = view_type)
+    agent_pos = get_agent_pos(env, view_type = view_type)
     agent_layer = get_agent_layer(grid, agent_pos)
     grid_with_agent = cat(agent_layer, grid, dims = 1)
 
-    agent = get_agent(env, Val{view_type}())
+    agent = get_agent(env, view_type = view_type)
     objects_with_agent = (agent, get_objects(env)...)
 
     GridWorldBase(grid_with_agent, objects_with_agent)

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -76,8 +76,8 @@ RLBase.get_actions(env::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGH
 RLBase.get_reward(env::AbstractGridWorld) = env.reward
 
 function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
-    env.reward = 0.0
-    agent = get_agent(env)
-    set_dir!(agent, action(get_dir(agent)))
-    env
+    set_reward!(env, 0.0)
+    dir = get_agent_dir(env)
+    set_agent_dir!(env, action(dir))
+    return env
 end

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -21,18 +21,14 @@ get_height(env::AbstractGridWorld) = size(get_world(env), 2)
 get_width(env::AbstractGridWorld) = size(get_world(env), 3)
 
 get_agent(env::AbstractGridWorld, ::Val{:full_view}) = env.agent
-get_agent(env::AbstractGridWorld, ::Val{:agent_view}) = Agent(dir = DOWN)
+get_agent(env::AbstractGridWorld, ::Val{:agent_view}) = Agent(dir = DOWN, pos = CartesianIndex(1, size(get_grid(env, Val{:agent_view}()), 3) ÷ 2 + 1))
 get_agent(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent(env, Val{view_type}())
 set_agent!(env::AbstractGridWorld, agent::Agent) = env.agent = agent
 
-get_agent_pos(env::AbstractGridWorld, ::Val{:full_view}) = env.agent_pos
-get_agent_pos(env::AbstractGridWorld, ::Val{:agent_view}) = CartesianIndex(1, size(get_grid(env, Val{:agent_view}()), 3) ÷ 2 + 1)
-get_agent_pos(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent_pos(env, Val{view_type}())
-set_agent_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = env.agent_pos = pos
+get_agent_pos(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_pos(get_agent(env, Val{view_type}()))
+set_agent_pos!(env::AbstractGridWorld, pos::CartesianIndex) = set_pos!(get_agent(env), pos)
 
-get_agent_dir(env::AbstractGridWorld, ::Val{:full_view}) = env |> get_agent |> get_dir
-get_agent_dir(env::AbstractGridWorld, ::Val{:agent_view}) = DOWN
-get_agent_dir(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent_dir(env, Val{view_type}())
+get_agent_dir(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_dir(get_agent(env, Val{view_type}()))
 set_agent_dir!(env::AbstractGridWorld, dir::Direction) = set_dir!(get_agent(env), dir)
 
 function get_agent_view(env::AbstractGridWorld, agent_view_size = (7,7))

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -61,7 +61,7 @@ end
 
 set_reward!(env::AbstractGridWorld, reward) = env.reward = reward
 
-function get_world_with_agent(env::AbstractGridWorld, view_type::Symbol = :full_view)
+function get_world_with_agent(env::AbstractGridWorld; view_type::Symbol = :full_view)
     grid = get_grid(env, Val{view_type}())
     agent_pos = get_agent_pos(env, Val{view_type}())
     agent_layer = get_agent_layer(grid, agent_pos)

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -81,3 +81,21 @@ function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
     set_agent_dir!(env, action(dir))
     return env
 end
+
+function (env::AbstractGridWorld)(::MoveForward)
+    world = get_world(env)
+
+    set_reward!(env, 0.0)
+
+    dir = get_agent_dir(env)
+    dest = dir(get_agent_pos(env))
+
+    if !world[WALL, dest]
+        set_agent_pos!(env, dest)
+        if world[GOAL, get_agent_pos(env)]
+            set_reward!(env, env.goal_reward)
+        end
+    end
+
+    return env
+end

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -34,7 +34,7 @@ set_agent_dir!(env::AbstractGridWorld, dir::Direction) = set_dir!(get_agent(env)
 
 function get_agent_view(env::AbstractGridWorld, agent_view_size = (7,7))
     world = get_world(env)
-    agent_view = BitArray{3}(undef, size(world, 1), agent_view_size...)
+    agent_view = BitArray{3}(undef, get_num_objects(env), agent_view_size...)
     fill!(agent_view, false)
     get_agent_view!(agent_view, env)
 end

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -75,6 +75,8 @@ RLBase.get_actions(env::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGH
 
 RLBase.get_reward(env::AbstractGridWorld) = env.reward
 
+RLBase.get_terminal(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
+
 function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
     set_reward!(env, 0.0)
     dir = get_agent_dir(env)

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -61,6 +61,18 @@ end
 
 set_reward!(env::AbstractGridWorld, reward) = env.reward = reward
 
+function get_world_with_agent(env::AbstractGridWorld, view_type::Symbol = :full_view)
+    grid = get_grid(env, Val{view_type}())
+    agent_pos = get_agent_pos(env, Val{view_type}())
+    agent_layer = get_agent_layer(grid, agent_pos)
+    grid_with_agent = cat(agent_layer, grid, dims = 1)
+
+    agent = get_agent(env, Val{view_type}())
+    objects_with_agent = (agent, get_objects(env)...)
+
+    GridWorldBase(grid_with_agent, objects_with_agent)
+end
+
 #####
 # RLBase API defaults
 #####

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,5 +1,5 @@
 export AbstractGridWorld
-export get_world, get_grid, get_objects, get_height, get_width, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_agent_view!, get_full_view
+export get_world, get_grid, get_objects, get_num_objects, get_height, get_width, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_agent_view!, get_full_view
 export set_world!, set_agent!, set_agent_pos!, set_agent_dir!, set_reward!
 
 abstract type AbstractGridWorld <: AbstractEnv end
@@ -17,6 +17,7 @@ get_grid(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_grid(env,
 
 get_objects(env::AbstractGridWorld) = env |> get_world |> get_objects
 
+get_num_objects(env::AbstractGridWorld) = env |> get_world |> get_num_objects
 get_height(env::AbstractGridWorld) = size(get_world(env), 2)
 get_width(env::AbstractGridWorld) = size(get_world(env), 3)
 

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -2,7 +2,6 @@ export CollectGems
 
 mutable struct CollectGems{R} <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Gem}}
-    agent_pos::CartesianIndex{2}
     agent::Agent
     num_gem_init::Int
     num_gem_current::Int
@@ -24,7 +23,7 @@ function CollectGems(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start
     gem_reward = 1.0
     reward = 0.0
 
-    env = CollectGems(world, agent_start_pos, Agent(dir = agent_start_dir), num_gem_init, num_gem_current, gem_reward, reward, rng)
+    env = CollectGems(world, Agent(dir = agent_start_dir, pos = agent_start_pos), num_gem_init, num_gem_current, gem_reward, reward, rng)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir)
 

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -4,7 +4,6 @@ using Random
 
 mutable struct DoorKey{W<:GridWorldBase, R} <: AbstractGridWorld
     world::W
-    agent_pos::CartesianIndex{2}
     agent::Agent
     goal_reward::Float64
     reward::Float64
@@ -26,7 +25,7 @@ function DoorKey(; n = 7, agent_start_pos = CartesianIndex(2,2), agent_start_dir
     goal_reward = 1.0
     reward = 0.0
 
-    env = DoorKey(world, agent_start_pos, Agent(dir = agent_start_dir), goal_reward, reward, rng)
+    env = DoorKey(world, Agent(dir = agent_start_dir, pos = agent_start_pos), goal_reward, reward, rng)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -4,7 +4,6 @@ using Random
 
 mutable struct DynamicObstacles{R} <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Obstacle,Goal}}
-    agent_pos::CartesianIndex{2}
     agent::Agent
     num_obstacles::Int
     obstacle_pos::Array{CartesianIndex{2},1}
@@ -27,7 +26,7 @@ function DynamicObstacles(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_
     goal_reward = 1.0
     reward = 0.0
 
-    env = DynamicObstacles(world, agent_start_pos, Agent(dir = agent_start_dir), num_obstacles, obstacle_pos, obstacle_reward, goal_reward, reward, rng)
+    env = DynamicObstacles(world, Agent(dir = agent_start_dir, pos = agent_start_pos), num_obstacles, obstacle_pos, obstacle_reward, goal_reward, reward, rng)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -25,24 +25,6 @@ function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_st
     return env
 end
 
-function (env::EmptyGridWorld)(::MoveForward)
-    world = get_world(env)
-
-    set_reward!(env, 0.0)
-
-    dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
-
-    if !world[WALL, dest]
-        set_agent_pos!(env, dest)
-        if world[GOAL, get_agent_pos(env)]
-            set_reward!(env, env.goal_reward)
-        end
-    end
-
-    return env
-end
-
 RLBase.get_terminal(env::EmptyGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -25,8 +25,6 @@ function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_st
     return env
 end
 
-RLBase.get_terminal(env::EmptyGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
-
 function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
 

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -2,7 +2,6 @@ export EmptyGridWorld
 
 mutable struct EmptyGridWorld <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Goal}}
-    agent_pos::CartesianIndex{2}
     agent::Agent
     goal_reward::Float64
     reward::Float64
@@ -18,7 +17,7 @@ function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_st
     goal_reward = 1.0
     reward = 0.0
 
-    env = EmptyGridWorld(world, agent_start_pos, Agent(dir = agent_start_dir), goal_reward, reward)
+    env = EmptyGridWorld(world, Agent(dir = agent_start_dir, pos = agent_start_pos), goal_reward, reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -30,8 +30,6 @@ function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2,2), agent_start_d
     return env
 end
 
-RLBase.get_terminal(env::FourRooms) = get_world(env)[GOAL, get_agent_pos(env)]
-
 function RLBase.reset!(env::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
 

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -30,24 +30,6 @@ function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2,2), agent_start_d
     return env
 end
 
-function (env::FourRooms)(::MoveForward)
-    world = get_world(env)
-
-    set_reward!(env, 0.0)
-
-    dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
-
-    if !world[WALL, dest]
-        set_agent_pos!(env, dest)
-        if world[GOAL, get_agent_pos(env)]
-            set_reward!(env, env.goal_reward)
-        end
-    end
-
-    return env
-end
-
 RLBase.get_terminal(env::FourRooms) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -2,13 +2,12 @@ export FourRooms
 
 mutable struct FourRooms <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Goal}}
-    agent_pos::CartesianIndex{2}
     agent::Agent
     goal_reward::Float64
     reward::Float64
 end
 
-function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1))
+function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n - 1, n - 1))
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
 
@@ -23,7 +22,7 @@ function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2,2), agent_start_d
     goal_reward = 1.0
     reward = 0.0
 
-    env = FourRooms(world, agent_start_pos, Agent(dir = RIGHT), goal_reward, reward)
+    env = FourRooms(world, Agent(dir = RIGHT, pos = agent_start_pos), goal_reward, reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -4,7 +4,6 @@ using Random
 
 mutable struct GoToDoor{W<:GridWorldBase, R} <: AbstractGridWorld
     world::W
-    agent_pos::CartesianIndex{2}
     agent::Agent
     target::Door
     target_reward::Float64
@@ -25,7 +24,7 @@ function GoToDoor(; n = 8, agent_start_pos = CartesianIndex(2,2), rng = Random.G
     penalty = -1.0
     reward = 0.0
 
-    env = GoToDoor(world, agent_start_pos, Agent(dir = RIGHT), doors[1], target_reward, penalty, reward, rng)
+    env = GoToDoor(world, Agent(dir = RIGHT, pos = agent_start_pos), doors[1], target_reward, penalty, reward, rng)
 
     reset!(env)
 
@@ -56,7 +55,7 @@ end
 
 RLBase.get_state(env::GoToDoor) = (get_agent_view(env), env.target)
 
-RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[x, env.agent_pos] for x in get_objects(env)[end-3:end]])
+RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[x, get_agent_pos(env)] for x in get_objects(env)[end-3:end]])
 
 function RLBase.reset!(env::GoToDoor)
     world = get_world(env)

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -55,8 +55,6 @@ end
 # RLBase API
 #####
 
-RLBase.get_terminal(env::SequentialRooms) = get_world(env)[GOAL, get_agent_pos(env)]
-
 function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)
     world = get_world(env)
 

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -26,7 +26,6 @@ end
 
 mutable struct SequentialRooms{R} <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Goal}}
-    agent_pos::CartesianIndex{2}
     agent::Agent
     num_rooms::Int
     room_length_range::UnitRange{Int}
@@ -44,7 +43,7 @@ function SequentialRooms(; num_rooms = 3, room_length_range = 4:6, agent_start_d
     goal_reward = 1.0
     reward = 0.0
 
-    env = SequentialRooms(world, CartesianIndex(1, 1), Agent(dir = agent_start_dir), num_rooms, room_length_range, Room[], goal_reward, reward, rng)
+    env = SequentialRooms(world, Agent(dir = agent_start_dir), num_rooms, room_length_range, Room[], goal_reward, reward, rng)
 
     reset!(env, agent_start_dir = agent_start_dir)
 
@@ -99,7 +98,7 @@ function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)
     # add the GOAL randomly in the last room
     world = get_world(env)
     goal_pos = rand(env.rng, get_interior(env.rooms[end]))
-    while goal_pos == env.agent_pos
+    while goal_pos == get_agent_pos(env)
         goal_pos = rand(env.rng, get_interior(env.rooms[end]))
     end
     world[GOAL, goal_pos] = true

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -55,24 +55,6 @@ end
 # RLBase API
 #####
 
-function (env::SequentialRooms)(::MoveForward)
-    world = get_world(env)
-
-    set_reward!(env, 0.0)
-
-    dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
-
-    if !world[WALL, dest]
-        set_agent_pos!(env, dest)
-        if world[GOAL, get_agent_pos(env)]
-            set_reward!(env, env.goal_reward)
-        end
-    end
-
-    return env
-end
-
 RLBase.get_terminal(env::SequentialRooms) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,5 +1,5 @@
 export GridWorldBase
-export get_grid, get_objects, get_height, get_width, switch!, get_agent_view!
+export get_grid, get_objects, get_num_objects, get_height, get_width, switch!, get_agent_view!
 
 using MacroTools:@forward
 using Random
@@ -25,6 +25,7 @@ end
 get_grid(world::GridWorldBase) = world.grid
 get_objects(world::GridWorldBase) = world.objects
 
+get_num_objects(world::GridWorldBase) = world |> get_objects |> length
 get_height(world::GridWorldBase) = size(world, 2)
 get_width(world::GridWorldBase) = size(world, 3)
 

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -57,6 +57,7 @@ get_color(::Obstacle) = :blue
 Base.@kwdef mutable struct Agent <: AbstractObject
     color::Symbol = :red
     dir::Direction = RIGHT
+    pos::CartesianIndex = CartesianIndex(1, 1)
     inventory::Union{Nothing, AbstractObject, Vector} = nothing
 end
 
@@ -75,6 +76,8 @@ end
 get_color(agent::Agent) = agent.color
 get_dir(agent::Agent) = agent.dir
 set_dir!(agent::Agent, dir::Direction) = agent.dir = dir
+get_pos(agent::Agent) = agent.pos
+set_pos!(agent::Agent, pos::CartesianIndex) = agent.pos = pos
 
 struct Transportable end
 const TRANSPORTABLE = Transportable()

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -55,9 +55,9 @@ get_color(::Obstacle) = :blue
 #####
 
 Base.@kwdef mutable struct Agent <: AbstractObject
-    color::Symbol=:red
-    dir::Direction
-    inventory::Union{Nothing, AbstractObject, Vector}=nothing
+    color::Symbol = :red
+    dir::Direction = RIGHT
+    inventory::Union{Nothing, AbstractObject, Vector} = nothing
 end
 
 function get_char(agent::Agent)

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -74,7 +74,7 @@ end
 
 get_color(agent::Agent) = agent.color
 get_dir(agent::Agent) = agent.dir
-set_dir!(agent::Agent, dir) = agent.dir = dir
+set_dir!(agent::Agent, dir::Direction) = agent.dir = dir
 
 struct Transportable end
 const TRANSPORTABLE = Transportable()

--- a/src/terminal_rendering.jl
+++ b/src/terminal_rendering.jl
@@ -4,28 +4,23 @@ get_background(env::AbstractGridWorld, pos::CartesianIndex{2}, ::Val{:agent_view
 get_background(env::AbstractGridWorld, pos::CartesianIndex{2}, ::Val{:full_view}) = pos in get_agent_view_inds(env) ? :dark_gray : :black
 
 function print_grid(io::IO, env::AbstractGridWorld, view_type)
-    grid = get_grid(env, Val{view_type}())
-    agent = get_agent(env, Val{view_type}())
-    agent_pos = get_agent_pos(env, Val{view_type}())
-    agent_layer = get_agent_layer(grid, agent_pos)
-    grid = cat(agent_layer, grid, dims = 1)
+    world = get_world_with_agent(env, view_type = view_type)
+    objects = get_objects(world)
 
-    objects = (agent, get_objects(env)...)
-
-    for i in 1:size(grid, 2)
-        for j in 1:size(grid, 3)
+    for i in 1:get_height(world)
+        for j in 1:get_width(world)
             pos = CartesianIndex(i, j)
-            idx = findfirst(grid[:, pos])
+            idx = findfirst(world[:, pos])
             if isnothing(idx)
-                o = nothing
+                object = nothing
                 foreground = :white
-                c = '_'
+                char = '_'
             else
-                o = objects[idx]
-                foreground = get_color(o)
-                c = get_char(o)
+                object = objects[idx]
+                foreground = get_color(object)
+                char = get_char(object)
             end
-            print(io, Crayon(background = get_background(env, pos, Val{view_type}()), foreground = foreground, bold = true, reset = true), c)
+            print(io, Crayon(background = get_background(env, pos, Val{view_type}()), foreground = foreground, bold = true, reset = true), char)
         end
         println(io, Crayon(reset = true))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,19 +12,19 @@ ACTIONS = [TURN_LEFT, TURN_RIGHT, MOVE_FORWARD]
         @testset "$(Env)" begin
             env = Env()
             @test typeof(get_agent_pos(env)) == CartesianIndex{2}
-            @test typeof(env.agent.dir) <: Direction
-            @test size(env.world.grid, 1) == length(env.world.objects)
-            @test 1 ≤ get_agent_pos(env)[1] ≤ size(env.world.grid, 2)
-            @test 1 ≤ get_agent_pos(env)[2] ≤ size(env.world.grid, 3)
+            @test typeof(get_agent_dir(env)) <: Direction
+            @test size(get_grid(env), 1) == length(get_objects(env))
+            @test 1 ≤ get_agent_pos(env)[1] ≤ get_height(env)
+            @test 1 ≤ get_agent_pos(env)[2] ≤ get_width(env)
 
             for _=1:1000
                 env = env(rand(ACTIONS))
-                @test 1 ≤ get_agent_pos(env)[1] ≤ size(env.world.grid, 2)
-                @test 1 ≤ get_agent_pos(env)[2] ≤ size(env.world.grid, 3)
-                @test env.world[WALL, get_agent_pos(env)] == false
+                @test 1 ≤ get_agent_pos(env)[1] ≤ get_height(env)
+                @test 1 ≤ get_agent_pos(env)[2] ≤ get_width(env)
+                @test get_world(env)[WALL, get_agent_pos(env)] == false
                 view = get_agent_view(env)
                 @test typeof(view) <: BitArray{3}
-                @test size(view,1) == length(env.world.objects)
+                @test size(view,1) == length(get_objects(env))
                 @test size(view,2) == 7
                 @test size(view,3) == 7
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,17 +11,17 @@ ACTIONS = [TURN_LEFT, TURN_RIGHT, MOVE_FORWARD]
     for Env in ENVS
         @testset "$(Env)" begin
             env = Env()
-            @test typeof(env.agent_pos) == CartesianIndex{2}
+            @test typeof(get_agent_pos(env)) == CartesianIndex{2}
             @test typeof(env.agent.dir) <: Direction
             @test size(env.world.grid, 1) == length(env.world.objects)
-            @test 1 ≤ env.agent_pos[1] ≤ size(env.world.grid, 2)
-            @test 1 ≤ env.agent_pos[2] ≤ size(env.world.grid, 3)
+            @test 1 ≤ get_agent_pos(env)[1] ≤ size(env.world.grid, 2)
+            @test 1 ≤ get_agent_pos(env)[2] ≤ size(env.world.grid, 3)
 
             for _=1:1000
                 env = env(rand(ACTIONS))
-                @test 1 ≤ env.agent_pos[1] ≤ size(env.world.grid, 2)
-                @test 1 ≤ env.agent_pos[2] ≤ size(env.world.grid, 3)
-                @test env.world[WALL, env.agent_pos] == false
+                @test 1 ≤ get_agent_pos(env)[1] ≤ size(env.world.grid, 2)
+                @test 1 ≤ get_agent_pos(env)[2] ≤ size(env.world.grid, 3)
+                @test env.world[WALL, get_agent_pos(env)] == false
                 view = get_agent_view(env)
                 @test typeof(view) <: BitArray{3}
                 @test size(view,1) == length(env.world.objects)


### PR DESCRIPTION
1. Track agent's position as a field inside the `Agent` struct (as opposed to a field inside the environment struct)
1. Factor out `(env::AbstractGridWorld)(::MoveForward)` behaviour for vanilla goal-based environments (`EmptyGridWorld`, `FourRooms`, `SequentialRooms`)
1. Add method `get_world_with_agent` to make terminal rendering more modular.
1. Add method `get_num_objects`, just like `get_height` and `get_width`
1. Little bit of cleaning up here and there.
