### PR TITLE
Make rng a standard component of every env struct

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -70,6 +70,8 @@ function get_world_with_agent(env::AbstractGridWorld; view_type::Symbol = :full_
     GridWorldBase(grid_with_agent, objects_with_agent)
 end
 
+get_rng(env::AbstractGridWorld) = env.rng
+
 #####
 # RLBase API defaults
 #####

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -56,6 +56,7 @@ RLBase.get_terminal(env::CollectGems) = env.num_gem_current <= 0
 function RLBase.reset!(env::CollectGems; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT)
     world = get_world(env)
     n = get_width(env)
+    rng = get_rng(env)
 
     world[EMPTY, 2:n-1, 2:n-1] .= true
     world[GEM, 1:n, 1:n] .= false
@@ -70,7 +71,7 @@ function RLBase.reset!(env::CollectGems; agent_start_pos = CartesianIndex(2, 2),
 
     gem_placed = 0
     while gem_placed < env.num_gem_init
-        gem_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 2:n-1))
+        gem_pos = CartesianIndex(rand(rng, 2:n-1), rand(rng, 2:n-1))
         if (gem_pos == get_agent_pos(env)) || (world[GEM, gem_pos] == true)
             continue
         else

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -70,6 +70,7 @@ RLBase.get_terminal(env::DoorKey) = get_world(env)[GOAL, get_agent_pos(env)]
 function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
     n = get_width(env)
+    rng = get_rng(env)
 
     objects = get_objects(env)
     door = objects[end - 1]
@@ -81,16 +82,16 @@ function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), age
 
     set_agent_dir!(env, agent_start_dir)
 
-    door_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 3:n-2))
+    door_pos = CartesianIndex(rand(rng, 2:n-1), rand(rng, 3:n-2))
     @assert agent_start_pos[2] < door_pos[2] "Agent should start on the left side of the door"
     @assert goal_pos[2] > door_pos[2] "Goal should be placed on the right side of the door"
     world[WALL, :, door_pos[2]] .= true
     world[door, door_pos] = true
     world[WALL, door_pos] = false
 
-    key_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 2:door_pos[2]-1))
+    key_pos = CartesianIndex(rand(rng, 2:n-1), rand(rng, 2:door_pos[2]-1))
     while key_pos == agent_start_pos
-        key_pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 2:door_pos[2]-1))
+        key_pos = CartesianIndex(rand(rng, 2:n-1), rand(rng, 2:door_pos[2]-1))
     end
     world[key, key_pos] = true
 

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -82,7 +82,7 @@ function update_obstacles!(env::DynamicObstacles)
         world[EMPTY, pos] = true
         world[OBSTACLE, pos] = false
 
-        new_pos = rand(env.rng, valid_obstacle_dest(env, pos))
+        new_pos = rand(get_rng(env), valid_obstacle_dest(env, pos))
         env.obstacle_pos[i] = new_pos
 
         world[EMPTY, new_pos] = false
@@ -97,6 +97,7 @@ RLBase.get_terminal(env::DynamicObstacles) = iscollision(env) || get_world(env)[
 function RLBase.reset!(env::DynamicObstacles; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
     n = get_width(env)
+    rng = get_rng(env)
 
     world[EMPTY, 2:n-1, 2:n-1] .= true
     world[GOAL, goal_pos] = true
@@ -110,7 +111,7 @@ function RLBase.reset!(env::DynamicObstacles; agent_start_pos = CartesianIndex(2
 
     obstacles_placed = 0
     while obstacles_placed < env.num_obstacles
-        pos = CartesianIndex(rand(env.rng, 2:n-1), rand(env.rng, 2:n-1))
+        pos = CartesianIndex(rand(rng, 2:n-1), rand(rng, 2:n-1))
         if (pos == get_agent_pos(env)) || (world[OBSTACLE, pos] == true) || (pos == goal_pos)
             continue
         else

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -1,13 +1,14 @@
 export EmptyGridWorld
 
-mutable struct EmptyGridWorld <: AbstractGridWorld
+mutable struct EmptyGridWorld{R} <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Goal}}
     agent::Agent
     goal_reward::Float64
     reward::Float64
+    rng::R
 end
 
-function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1))
+function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
 
@@ -17,7 +18,7 @@ function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_st
     goal_reward = 1.0
     reward = 0.0
 
-    env = EmptyGridWorld(world, Agent(dir = agent_start_dir, pos = agent_start_pos), goal_reward, reward)
+    env = EmptyGridWorld(world, Agent(dir = agent_start_dir, pos = agent_start_pos), goal_reward, reward, rng)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -1,13 +1,14 @@
 export FourRooms
 
-mutable struct FourRooms <: AbstractGridWorld
+mutable struct FourRooms{R} <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Goal}}
     agent::Agent
     goal_reward::Float64
     reward::Float64
+    rng::R
 end
 
-function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n - 1, n - 1))
+function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n - 1, n - 1), rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
 
@@ -22,7 +23,7 @@ function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2, 2), agent_start_
     goal_reward = 1.0
     reward = 0.0
 
-    env = FourRooms(world, Agent(dir = RIGHT, pos = agent_start_pos), goal_reward, reward)
+    env = FourRooms(world, Agent(dir = RIGHT, pos = agent_start_pos), goal_reward, reward, rng)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -59,6 +59,7 @@ RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[x, get_agent_pos(env)] 
 
 function RLBase.reset!(env::GoToDoor)
     world = get_world(env)
+    rng = get_rng(env)
 
     n = get_width(env)
 
@@ -70,15 +71,15 @@ function RLBase.reset!(env::GoToDoor)
         world[door, :, :] .= false
     end
 
-    env.target = rand(env.rng, doors)
+    env.target = rand(rng, doors)
     set_reward!(env, 0.0)
 
-    door_pos = [CartesianIndex(rand(env.rng, 2:n-1),1),
-                CartesianIndex(rand(env.rng, 2:n-1),n),
-                CartesianIndex(1,rand(env.rng, 2:n-1)),
-                CartesianIndex(n,rand(env.rng, 2:n-1))]
+    door_pos = [CartesianIndex(rand(rng, 2:n-1),1),
+                CartesianIndex(rand(rng, 2:n-1),n),
+                CartesianIndex(1,rand(rng, 2:n-1)),
+                CartesianIndex(n,rand(rng, 2:n-1))]
 
-    rp = randperm(env.rng, length(door_pos))
+    rp = randperm(rng, length(door_pos))
 
     for (door, pos) in zip(doors, door_pos[rp])
         world[door, pos] = true

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -56,6 +56,7 @@ end
 
 function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)
     world = get_world(env)
+    rng = get_rng(env)
 
     world[:, :, :] .= false
 
@@ -76,10 +77,10 @@ function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)
         candidate_rooms = generate_candidate_rooms(env)
 
         if length(candidate_rooms) > 0
-            room = rand(env.rng, candidate_rooms)
+            room = rand(rng, candidate_rooms)
             add_room!(env, room)
 
-            door_pos = rand(env.rng, intersect(env.rooms[end - 1].region, room.region)[2:end-1])
+            door_pos = rand(rng, intersect(env.rooms[end - 1].region, room.region)[2:end-1])
             world[WALL, door_pos] = false
             world[EMPTY, door_pos] = true
         end
@@ -93,13 +94,13 @@ function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)
     set_world!(env, centered_world)
 
     # add the agent randomly in the first room
-    set_agent_pos!(env, rand(env.rng, get_interior(env.rooms[1])))
+    set_agent_pos!(env, rand(rng, get_interior(env.rooms[1])))
 
     # add the GOAL randomly in the last room
     world = get_world(env)
-    goal_pos = rand(env.rng, get_interior(env.rooms[end]))
+    goal_pos = rand(rng, get_interior(env.rooms[end]))
     while goal_pos == get_agent_pos(env)
-        goal_pos = rand(env.rng, get_interior(env.rooms[end]))
+        goal_pos = rand(rng, get_interior(env.rooms[end]))
     end
     world[GOAL, goal_pos] = true
     world[EMPTY, goal_pos] = false
@@ -113,9 +114,10 @@ end
 
 function generate_first_room(env::AbstractGridWorld)
     big_n = get_width(env)
+    rng = get_rng(env)
     origin = CartesianIndex(big_n ÷ 2 + 1, big_n ÷ 2 + 1)
-    height = rand(env.rng, env.room_length_range)
-    width = rand(env.rng, env.room_length_range)
+    height = rand(rng, env.room_length_range)
+    width = rand(rng, env.room_length_range)
     room = Room(origin, height, width)
     return room
 end


### PR DESCRIPTION
Have `rng` as a standard component of an environment struct. It is often very useful.
1. Add `rng` field to `EmptyGridWorld` and `FourRooms`.
1. Add a `get_rng` method and use it in place of `env.rng`