### PR TITLE
Refactor and Clean Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ play(env;file_name="example.gif",frame_rate=5)
 
     <img src="https://github.com/JuliaReinforcementLearning/GridWorlds.jl/raw/master/docs/src/assets/img/FourRooms.gif" width="300px">
 
+1. ### SequentialRooms
+
+    <img src="https://github.com/JuliaReinforcementLearning/GridWorlds.jl/raw/master/docs/src/assets/img/SequentialRooms.gif" width="300px">
+
 1. ### GoToDoor
 
     <img src="https://github.com/JuliaReinforcementLearning/GridWorlds.jl/raw/master/docs/src/assets/img/GoToDoor.gif" width="300px">
@@ -70,7 +74,3 @@ play(env;file_name="example.gif",frame_rate=5)
 1. ### DynamicObstacles
 
     <img src="https://github.com/JuliaReinforcementLearning/GridWorlds.jl/raw/master/docs/src/assets/img/DynamicObstacles.gif" width="300px">
-
-1. ### SequentialRooms
-
-    <img src="https://github.com/JuliaReinforcementLearning/GridWorlds.jl/raw/master/docs/src/assets/img/SequentialRooms.gif" width="300px">

--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -3,6 +3,7 @@ module GridWorlds
 export GW
 
 import Requires
+using Random
 using ReinforcementLearningBase
 
 const GW = GridWorlds

--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -1,10 +1,11 @@
 module GridWorlds
 
-using Requires
+export GW
+
+import Requires
 using ReinforcementLearningBase
 
 const GW = GridWorlds
-export GW
 
 include("directions.jl")
 include("actions.jl")
@@ -15,7 +16,7 @@ include("envs/envs.jl")
 include("terminal_rendering.jl")
 
 function __init__()
-    @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("makie_rendering.jl")
+    Requires.@require Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("makie_rendering.jl")
 end
 
 end

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -89,25 +89,26 @@ RLBase.get_reward(env::AbstractGridWorld) = env.reward
 RLBase.get_terminal(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
-    set_reward!(env, 0.0)
     dir = get_agent_dir(env)
     set_agent_dir!(env, action(dir))
+
+    set_reward!(env, 0.0)
+
     return env
 end
 
 function (env::AbstractGridWorld)(::MoveForward)
     world = get_world(env)
 
-    set_reward!(env, 0.0)
-
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
-
     if !world[WALL, dest]
         set_agent_pos!(env, dest)
-        if world[GOAL, get_agent_pos(env)]
-            set_reward!(env, env.goal_reward)
-        end
+    end
+
+    set_reward!(env, 0.0)
+    if world[GOAL, get_agent_pos(env)]
+        set_reward!(env, env.goal_reward)
     end
 
     return env

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -1,9 +1,5 @@
-export AbstractGridWorldAction, MoveForward, TurnLeft, TurnRight
-export MOVE_FORWARD, TURN_LEFT, TURN_RIGHT
-
-#####
-# Actions
-#####
+export AbstractGridWorldAction, MoveForward, TurnLeft, TurnRight, Pickup, Drop
+export MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, PICK_UP, DROP
 
 abstract type AbstractGridWorldAction end
 

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -6,20 +6,21 @@ abstract type AbstractGridWorldAction end
 struct MoveForward <: AbstractGridWorldAction end
 const MOVE_FORWARD = MoveForward()
 
-struct TurnRight <: AbstractGridWorldAction end
-const TURN_RIGHT = TurnRight()
-
 struct TurnLeft <: AbstractGridWorldAction end
 const TURN_LEFT = TurnLeft()
 
-(x::TurnRight)(::Left) = UP
-(x::TurnRight)(::Up) = RIGHT
-(x::TurnRight)(::Right) = DOWN
-(x::TurnRight)(::Down) = LEFT
-(x::TurnLeft)(::Left) = DOWN
 (x::TurnLeft)(::Up) = LEFT
-(x::TurnLeft)(::Right) = UP
 (x::TurnLeft)(::Down) = RIGHT
+(x::TurnLeft)(::Left) = DOWN
+(x::TurnLeft)(::Right) = UP
+
+struct TurnRight <: AbstractGridWorldAction end
+const TURN_RIGHT = TurnRight()
+
+(x::TurnRight)(::Up) = RIGHT
+(x::TurnRight)(::Down) = LEFT
+(x::TurnRight)(::Left) = UP
+(x::TurnRight)(::Right) = DOWN
 
 struct Pickup <: AbstractGridWorldAction end
 const PICK_UP = Pickup()

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -13,7 +13,7 @@ end
 function CollectGems(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GEM)
     world = GridWorldBase(objects, n, n)
-    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    agent = Agent(pos = agent_start_pos, dir = agent_start_dir)
     reward = 0.0
     num_gem_init = n - 1
     num_gem_current = num_gem_init

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -3,27 +3,23 @@ export CollectGems
 mutable struct CollectGems{R} <: AbstractGridWorld
     world::GridWorldBase{Tuple{Empty,Wall,Gem}}
     agent::Agent
+    reward::Float64
+    rng::R
     num_gem_init::Int
     num_gem_current::Int
     gem_reward::Float64
-    reward::Float64
-    rng::R
 end
 
 function CollectGems(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GEM)
     world = GridWorldBase(objects, n, n)
-
-    world[WALL, [1,n], 1:n] .= true
-    world[WALL, 1:n, [1,n]] .= true
-
+    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    reward = 0.0
     num_gem_init = n - 1
     num_gem_current = num_gem_init
-
     gem_reward = 1.0
-    reward = 0.0
 
-    env = CollectGems(world, Agent(dir = agent_start_dir, pos = agent_start_pos), num_gem_init, num_gem_current, gem_reward, reward, rng)
+    env = CollectGems(world, agent, reward, rng, num_gem_init, num_gem_current, gem_reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir)
 
@@ -33,19 +29,19 @@ end
 function (env::CollectGems)(::MoveForward)
     world = get_world(env)
 
-    set_reward!(env, 0.0)
-
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
-
     if !world[WALL, dest]
         set_agent_pos!(env, dest)
-        if world[GEM, dest]
-            world[GEM, dest] = false
-            world[EMPTY, dest] = true
-            env.num_gem_current = env.num_gem_current - 1
-            set_reward!(env, env.gem_reward)
-        end
+    end
+
+    set_reward!(env, 0.0)
+    agent_pos = get_agent_pos(env)
+    if world[GEM, agent_pos]
+        world[GEM, agent_pos] = false
+        world[EMPTY, agent_pos] = true
+        env.num_gem_current = env.num_gem_current - 1
+        set_reward!(env, env.gem_reward)
     end
 
     return env
@@ -58,16 +54,12 @@ function RLBase.reset!(env::CollectGems; agent_start_pos = CartesianIndex(2, 2),
     n = get_width(env)
     rng = get_rng(env)
 
+    world[:, :, :] .= false
+    world[WALL, [1,n], 1:n] .= true
+    world[WALL, 1:n, [1,n]] .= true
     world[EMPTY, 2:n-1, 2:n-1] .= true
-    world[GEM, 1:n, 1:n] .= false
 
     env.num_gem_current = env.num_gem_init
-
-    set_reward!(env, 0.0)
-
-    set_agent_pos!(env, agent_start_pos)
-
-    set_agent_dir!(env, agent_start_dir)
 
     gem_placed = 0
     while gem_placed < env.num_gem_init
@@ -80,6 +72,11 @@ function RLBase.reset!(env::CollectGems; agent_start_pos = CartesianIndex(2, 2),
             gem_placed = gem_placed + 1
         end
     end
+
+    set_agent_pos!(env, agent_start_pos)
+    set_agent_dir!(env, agent_start_dir)
+
+    set_reward!(env, 0.0)
 
     return env
 end

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -13,7 +13,7 @@ function DoorKey(; n = 7, agent_start_pos = CartesianIndex(2,2), agent_start_dir
     key = Key(:yellow)
     objects = (EMPTY, WALL, GOAL, door, key)
     world = GridWorldBase(objects, n, n)
-    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    agent = Agent(pos = agent_start_pos, dir = agent_start_dir)
     reward = 0.0
     goal_reward = 1.0
 

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -14,7 +14,7 @@ end
 function DynamicObstacles(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), num_obstacles = n-3, rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, OBSTACLE, GOAL)
     world = GridWorldBase(objects, n, n)
-    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    agent = Agent(pos = agent_start_pos, dir = agent_start_dir)
     reward = 0.0
     goal_reward = 1.0
     obstacle_pos = Array{CartesianIndex{2}, 1}(undef, num_obstacles)

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -1,32 +1,26 @@
 export DynamicObstacles
 
-using Random
-
 mutable struct DynamicObstacles{R} <: AbstractGridWorld
-    world::GridWorldBase{Tuple{Empty,Wall,Obstacle,Goal}}
+    world::GridWorldBase{Tuple{Empty, Wall, Obstacle, Goal}}
     agent::Agent
+    reward::Float64
+    rng::R
+    goal_reward::Float64
     num_obstacles::Int
     obstacle_pos::Array{CartesianIndex{2},1}
     obstacle_reward::Float64
-    goal_reward::Float64
-    reward::Float64
-    rng::R
 end
 
 function DynamicObstacles(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), num_obstacles = n-3, rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, OBSTACLE, GOAL)
     world = GridWorldBase(objects, n, n)
-
-    world[WALL, [1,n], 1:n] .= true
-    world[WALL, 1:n, [1,n]] .= true
-
-    obstacle_pos = Array{CartesianIndex{2},1}(undef,num_obstacles)
-
-    obstacle_reward = -1.0
-    goal_reward = 1.0
+    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
     reward = 0.0
+    goal_reward = 1.0
+    obstacle_pos = Array{CartesianIndex{2}, 1}(undef, num_obstacles)
+    obstacle_reward = -1.0
 
-    env = DynamicObstacles(world, Agent(dir = agent_start_dir, pos = agent_start_pos), num_obstacles, obstacle_pos, obstacle_reward, goal_reward, reward, rng)
+    env = DynamicObstacles(world, agent, reward, rng, goal_reward, num_obstacles, obstacle_pos, obstacle_reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 
@@ -38,17 +32,15 @@ iscollision(env::DynamicObstacles) = get_world(env)[OBSTACLE, get_agent_pos(env)
 function (env::DynamicObstacles)(::MoveForward)
     world = get_world(env)
 
-    set_reward!(env, 0.0)
-
     update_obstacles!(env)
 
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
-
     if !world[WALL, dest]
         set_agent_pos!(env, dest)
     end
 
+    set_reward!(env, 0.0)
     if iscollision(env)
         set_reward!(env, env.obstacle_reward)
     end
@@ -57,12 +49,11 @@ function (env::DynamicObstacles)(::MoveForward)
 end
 
 function (env::DynamicObstacles)(action::Union{TurnRight, TurnLeft})
-    set_reward!(env, 0.0)
-
     update_obstacles!(env)
 
     set_dir!(get_agent(env), action(get_agent_dir(env)))
 
+    set_reward!(env, 0.0)
     if iscollision(env)
         set_reward!(env, env.obstacle_reward)
     end
@@ -99,15 +90,12 @@ function RLBase.reset!(env::DynamicObstacles; agent_start_pos = CartesianIndex(2
     n = get_width(env)
     rng = get_rng(env)
 
+    world[:, :, :] .= false
+    world[WALL, [1,n], 1:n] .= true
+    world[WALL, 1:n, [1,n]] .= true
     world[EMPTY, 2:n-1, 2:n-1] .= true
     world[GOAL, goal_pos] = true
     world[EMPTY, goal_pos] = false
-
-    set_reward!(env, 0.0)
-
-    set_agent_pos!(env, agent_start_pos)
-
-    set_agent_dir!(env, agent_start_dir)
 
     obstacles_placed = 0
     while obstacles_placed < env.num_obstacles
@@ -121,6 +109,11 @@ function RLBase.reset!(env::DynamicObstacles; agent_start_pos = CartesianIndex(2
             env.obstacle_pos[obstacles_placed] = pos
         end
     end
+
+    set_agent_pos!(env, agent_start_pos)
+    set_agent_dir!(env, agent_start_dir)
+
+    set_reward!(env, 0.0)
 
     return env
 end

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -11,7 +11,7 @@ end
 function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
-    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    agent = Agent(pos = agent_start_pos, dir = agent_start_dir)
     reward = 0.0
     goal_reward = 1.0
 

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -1,24 +1,21 @@
 export EmptyGridWorld
 
 mutable struct EmptyGridWorld{R} <: AbstractGridWorld
-    world::GridWorldBase{Tuple{Empty,Wall,Goal}}
+    world::GridWorldBase{Tuple{Empty, Wall, Goal}}
     agent::Agent
-    goal_reward::Float64
     reward::Float64
     rng::R
+    goal_reward::Float64
 end
 
 function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
-
-    world[WALL, [1,n], 1:n] .= true
-    world[WALL, 1:n, [1,n]] .= true
-
-    goal_reward = 1.0
+    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
     reward = 0.0
+    goal_reward = 1.0
 
-    env = EmptyGridWorld(world, Agent(dir = agent_start_dir, pos = agent_start_pos), goal_reward, reward, rng)
+    env = EmptyGridWorld(world, agent, reward, rng, goal_reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 
@@ -27,17 +24,19 @@ end
 
 function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
+    n = get_width(env)
 
-    set_reward!(env, 0.0)
+    world[:, :, :] .= false
+    world[WALL, [1,n], :] .= true
+    world[WALL, :, [1,n]] .= true
+    world[EMPTY, :, :] .= .!world[WALL, :, :]
+    world[GOAL, goal_pos] = true
+    world[EMPTY, goal_pos] = false
 
     set_agent_pos!(env, agent_start_pos)
-
     set_agent_dir!(env, agent_start_dir)
 
-    world[GOAL, :, :] .= false
-    world[GOAL, goal_pos] = true
-    world[EMPTY, :, :] .= .!world[WALL, :, :]
-    world[EMPTY, goal_pos] = false
+    set_reward!(env, 0.0)
 
     return env
 end

--- a/src/envs/envs.jl
+++ b/src/envs/envs.jl
@@ -1,7 +1,7 @@
 include("emptygridworld.jl")
 include("fourrooms.jl")
+include("sequentialrooms.jl")
 include("gotodoor.jl")
 include("doorkey.jl")
 include("collectgems.jl")
 include("dynamicobstacles.jl")
-include("sequentialrooms.jl")

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -1,29 +1,21 @@
 export FourRooms
 
 mutable struct FourRooms{R} <: AbstractGridWorld
-    world::GridWorldBase{Tuple{Empty,Wall,Goal}}
+    world::GridWorldBase{Tuple{Empty, Wall, Goal}}
     agent::Agent
-    goal_reward::Float64
     reward::Float64
     rng::R
+    goal_reward::Float64
 end
 
 function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n - 1, n - 1), rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
-
-    world[WALL, [1,n], 1:n] .= true
-    world[WALL, 1:n, [1,n]] .= true
-    world[WALL, ceil(Int,n/2), vcat(2:ceil(Int,n/4)-1,ceil(Int,n/4)+1:ceil(Int,n/2)-1,ceil(Int,n/2):ceil(Int,3*n/4)-1,ceil(Int,3*n/4)+1:n)] .= true
-    world[WALL, vcat(2:ceil(Int,n/4)-1,ceil(Int,n/4)+1:ceil(Int,n/2)-1,ceil(Int,n/2):ceil(Int,3*n/4)-1,ceil(Int,3*n/4)+1:n), ceil(Int,n/2)] .= true
-    world[EMPTY, :, :] .= .!world[WALL, :, :]
-    world[GOAL, goal_pos] = true
-    world[EMPTY, goal_pos] = false
-
-    goal_reward = 1.0
+    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
     reward = 0.0
+    goal_reward = 1.0
 
-    env = FourRooms(world, Agent(dir = RIGHT, pos = agent_start_pos), goal_reward, reward, rng)
+    env = FourRooms(world, agent, reward, rng, goal_reward)
 
     reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir, goal_pos = goal_pos)
 
@@ -32,17 +24,21 @@ end
 
 function RLBase.reset!(env::FourRooms; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
     world = get_world(env)
+    n = get_width(env)
 
-    set_reward!(env, 0.0)
+    world[:, :, :] .= false
+    world[WALL, [1, n], :] .= true
+    world[WALL, :, [1, n]] .= true
+    world[WALL, ceil(Int, n/2), vcat(2:ceil(Int, n/4)-1, ceil(Int, n/4)+1:ceil(Int, n/2)-1, ceil(Int, n/2):ceil(Int, 3*n/4)-1, ceil(Int, 3*n/4)+1:n)] .= true
+    world[WALL, vcat(2:ceil(Int, n/4)-1, ceil(Int, n/4)+1:ceil(Int, n/2)-1, ceil(Int, n/2):ceil(Int, 3*n/4)-1, ceil(Int, 3*n/4)+1:n), ceil(Int, n/2)] .= true
+    world[EMPTY, :, :] .= .!world[WALL, :, :]
+    world[GOAL, goal_pos] = true
+    world[EMPTY, goal_pos] = false
 
     set_agent_pos!(env, agent_start_pos)
-
     set_agent_dir!(env, agent_start_dir)
 
-    world[GOAL, :, :] .= false
-    world[GOAL, goal_pos] = true
-    world[EMPTY, :, :] .= .!world[WALL, :, :]
-    world[EMPTY, goal_pos] = false
+    set_reward!(env, 0.0)
 
     return env
 end

--- a/src/envs/fourrooms.jl
+++ b/src/envs/fourrooms.jl
@@ -11,7 +11,7 @@ end
 function FourRooms(; n = 9, agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n - 1, n - 1), rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GOAL)
     world = GridWorldBase(objects, n, n)
-    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    agent = Agent(pos = agent_start_pos, dir = agent_start_dir)
     reward = 0.0
     goal_reward = 1.0
 

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -1,32 +1,28 @@
 export GoToDoor
 
-using Random
-
 mutable struct GoToDoor{W<:GridWorldBase, R} <: AbstractGridWorld
     world::W
     agent::Agent
+    reward::Float64
+    rng::R
     target::Door
     target_reward::Float64
     penalty::Float64
-    reward::Float64
-    rng::R
 end
 
-function GoToDoor(; n = 8, agent_start_pos = CartesianIndex(2,2), rng = Random.GLOBAL_RNG)
+function GoToDoor(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, rng = Random.GLOBAL_RNG)
     doors = [Door(c) for c in COLORS[1:4]]
     objects = (EMPTY, WALL, doors...)
-
     world = GridWorldBase(objects, n, n)
-
-    world[EMPTY, 2:n-1, 2:n-1] .= true
-
+    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    reward = 0.0
+    target = doors[1]
     target_reward = 1.0
     penalty = -1.0
-    reward = 0.0
 
-    env = GoToDoor(world, Agent(dir = RIGHT, pos = agent_start_pos), doors[1], target_reward, penalty, reward, rng)
+    env = GoToDoor(world, agent, reward, rng, target, target_reward, penalty)
 
-    reset!(env)
+    reset!(env, agent_start_pos = agent_start_pos, agent_start_dir = agent_start_dir)
 
     return env
 end
@@ -34,19 +30,18 @@ end
 function (env::GoToDoor)(::MoveForward)
     world = get_world(env)
 
-    set_reward!(env, 0.0)
-
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
-
-    if dest ∈ CartesianIndices((size(world, 2), size(world, 3))) && !world[WALL,dest]
+    if dest ∈ CartesianIndices((get_height(env), get_width(env))) && !world[WALL, dest]
         set_agent_pos!(env, dest)
-        if get_terminal(env)
-            if world[env.target, get_agent_pos(env)]
-                set_reward!(env, env.target_reward)
-            else
-                set_reward!(env, env.penalty)
-            end
+    end
+
+    set_reward!(env, 0.0)
+    if get_terminal(env)
+        if world[env.target, get_agent_pos(env)]
+            set_reward!(env, env.target_reward)
+        else
+            set_reward!(env, env.penalty)
         end
     end
 
@@ -55,29 +50,25 @@ end
 
 RLBase.get_state(env::GoToDoor) = (get_agent_view(env), env.target)
 
-RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[x, get_agent_pos(env)] for x in get_objects(env)[end-3:end]])
+RLBase.get_terminal(env::GoToDoor) = any([get_world(env)[object, get_agent_pos(env)] for object in get_objects(env)[end-3:end]])
 
-function RLBase.reset!(env::GoToDoor)
+function RLBase.reset!(env::GoToDoor; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT)
     world = get_world(env)
+    n = get_width(env)
     rng = get_rng(env)
 
-    n = get_width(env)
-
+    world[:, :, :] .= false
     world[WALL, [1,n], 1:n] .= true
     world[WALL, 1:n, [1,n]] .= true
-
+    world[EMPTY, 2:n-1, 2:n-1] .= true
+    
     doors = get_objects(env)[end-3:end]
-    for door in doors
-        world[door, :, :] .= false
-    end
-
     env.target = rand(rng, doors)
-    set_reward!(env, 0.0)
 
-    door_pos = [CartesianIndex(rand(rng, 2:n-1),1),
-                CartesianIndex(rand(rng, 2:n-1),n),
-                CartesianIndex(1,rand(rng, 2:n-1)),
-                CartesianIndex(n,rand(rng, 2:n-1))]
+    door_pos = [CartesianIndex(rand(rng, 2:n-1), 1),
+                CartesianIndex(rand(rng, 2:n-1), n),
+                CartesianIndex(1, rand(rng, 2:n-1)),
+                CartesianIndex(n, rand(rng, 2:n-1))]
 
     rp = randperm(rng, length(door_pos))
 
@@ -85,6 +76,11 @@ function RLBase.reset!(env::GoToDoor)
         world[door, pos] = true
         world[WALL, pos] = false
     end
+
+    set_agent_pos!(env, agent_start_pos)
+    set_agent_dir!(env, agent_start_dir)
+
+    set_reward!(env, 0.0)
 
     return env
 end

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -14,7 +14,7 @@ function GoToDoor(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_di
     doors = [Door(c) for c in COLORS[1:4]]
     objects = (EMPTY, WALL, doors...)
     world = GridWorldBase(objects, n, n)
-    agent = Agent(dir = agent_start_dir, pos = agent_start_pos)
+    agent = Agent(pos = agent_start_pos, dir = agent_start_dir)
     reward = 0.0
     target = doors[1]
     target_reward = 1.0

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,7 +1,7 @@
 export GridWorldBase
 export get_grid, get_objects, get_num_objects, get_height, get_width, switch!, get_agent_view!
 
-using MacroTools:@forward
+import MacroTools
 import Random
 
 """
@@ -33,7 +33,7 @@ get_num_objects(world::GridWorldBase) = world |> get_grid |> get_num_objects
 get_height(world::GridWorldBase) = world |> get_grid |> get_height
 get_width(world::GridWorldBase) = world |> get_grid |> get_width
 
-@forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
+MacroTools.@forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
 
 @generated function Base.to_index(::GridWorldBase{O}, object::X) where {X<:AbstractObject, O}
     i = findfirst(X .=== O.parameters)

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,6 +1,6 @@
-export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE
 export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Agent
-export get_color, get_dir, set_dir!
+export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE
+export get_char, get_color, get_dir, set_dir!
 
 using Crayons
 using Colors

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -54,10 +54,10 @@ get_color(::Obstacle) = :blue
 #####
 
 Base.@kwdef mutable struct Agent <: AbstractObject
-    color::Symbol = :red
-    dir::Direction = RIGHT
     pos::CartesianIndex = CartesianIndex(1, 1)
+    dir::Direction = RIGHT
     inventory::Union{Nothing, AbstractObject, Vector} = nothing
+    color::Symbol = :red
 end
 
 function get_char(agent::Agent)

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -3,7 +3,6 @@ export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE, TRANSPORTABLE, NONTRANSPORTABLE
 export get_char, get_color, get_dir, set_dir!, get_pos, set_pos!, istransportable
 
 using Crayons
-using Colors
 
 const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
 
@@ -78,6 +77,10 @@ get_dir(agent::Agent) = agent.dir
 set_dir!(agent::Agent, dir::Direction) = agent.dir = dir
 get_pos(agent::Agent) = agent.pos
 set_pos!(agent::Agent, pos::CartesianIndex) = agent.pos = pos
+
+#####
+# Pickup & Drop objects
+#####
 
 struct Transportable end
 const TRANSPORTABLE = Transportable()

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,6 +1,6 @@
-export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Agent
-export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE
-export get_char, get_color, get_dir, set_dir!
+export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Agent, Transportable, NonTransportable
+export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE, TRANSPORTABLE, NONTRANSPORTABLE
+export get_char, get_color, get_dir, set_dir!, get_pos, set_pos!, istransportable
 
 using Crayons
 using Colors

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -2,7 +2,7 @@ export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Agent, Trans
 export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE, TRANSPORTABLE, NONTRANSPORTABLE
 export get_char, get_color, get_dir, set_dir!, get_pos, set_pos!, istransportable
 
-using Crayons
+import Crayons
 
 const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
 
@@ -12,7 +12,7 @@ const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
 
 abstract type AbstractObject end
 
-Base.show(io::IO, object::AbstractObject) = print(io, Crayon(foreground = get_color(object), reset = true), get_char(object))
+Base.show(io::IO, object::AbstractObject) = print(io, Crayons.Crayon(foreground = get_color(object), reset = true), get_char(object))
 
 struct Empty <: AbstractObject end
 const EMPTY = Empty()


### PR DESCRIPTION
1. Make the implementation of environments much more consistent across environments.
1. Decouple moving forward from the receiving reward or some special environment behavior.
1. Move all the world construction to `reset!`. The world's grid will be constructed entirely from scratch every time. This doesn't have a disproportionately high cost since we anyways need to pass through the entirely `GOAL` layer in order to reset the `GOAL`, for example.
1. Configurable `agent_start_pos` and `agent_start_dir` in `GoToDoor` environment.
1. Add and reuse `get_num_objects`, `get_height`, `get_width` methds for a `BitArray{3}`.
1. Change the ordering of environments. Keep the vanilla goal-seeking environments first.
1. Clean up imports and exports. Use `import Package` instead of `using Package` when `Package` is being used only in a few places.
1. Minor formatting and changing the order of things here and there.