### PR TITLE
Refactor Rendering

### DIFF
--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -86,6 +86,7 @@ function RLBase.reset!(env::DoorKey; agent_start_pos = CartesianIndex(2, 2), age
 
     set_agent_pos!(env, agent_start_pos)
     set_agent_dir!(env, agent_start_dir)
+    set_inventory!(env, nothing)
 
     set_reward!(env, 0.0)
 

--- a/src/envs/emptygridworld.jl
+++ b/src/envs/emptygridworld.jl
@@ -8,9 +8,9 @@ mutable struct EmptyGridWorld{R} <: AbstractGridWorld
     goal_reward::Float64
 end
 
-function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(n-1, n-1), rng = Random.GLOBAL_RNG)
+function EmptyGridWorld(; height = 8, width = 8, agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(height - 1, width - 1), rng = Random.GLOBAL_RNG)
     objects = (EMPTY, WALL, GOAL)
-    world = GridWorldBase(objects, n, n)
+    world = GridWorldBase(objects, height, width)
     agent = Agent(pos = agent_start_pos, dir = agent_start_dir)
     reward = 0.0
     goal_reward = 1.0
@@ -22,13 +22,14 @@ function EmptyGridWorld(; n = 8, agent_start_pos = CartesianIndex(2,2), agent_st
     return env
 end
 
-function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_width(env) - 1, get_width(env) - 1))
+function RLBase.reset!(env::EmptyGridWorld; agent_start_pos = CartesianIndex(2, 2), agent_start_dir = RIGHT, goal_pos = CartesianIndex(get_height(env) - 1, get_width(env) - 1))
     world = get_world(env)
-    n = get_width(env)
+    height = get_height(env)
+    width = get_width(env)
 
     world[:, :, :] .= false
-    world[WALL, [1,n], :] .= true
-    world[WALL, :, [1,n]] .= true
+    world[WALL, [1, height], :] .= true
+    world[WALL, :, [1, width]] .= true
     world[EMPTY, :, :] .= .!world[WALL, :, :]
     world[GOAL, goal_pos] = true
     world[EMPTY, goal_pos] = false

--- a/src/makie_rendering.jl
+++ b/src/makie_rendering.jl
@@ -5,39 +5,41 @@ using .Makie
 # coordinate transform for Makie.jl
 get_transform(x::Int) = pos -> CartesianIndex(pos[2], x - pos[1] + 1)
 
+get_markersize(object::Nothing, tile_size) = reverse(tile_size) ./ 2
+get_markersize(object::AbstractObject, tile_size) = reverse(tile_size)
+get_markersize(object::Empty, tile_size) = reverse(tile_size) ./ 5
+
 function init_screen(env_node::Observable{<:AbstractGridWorld}; resolution = (1000, 1000))
     scene = Scene(resolution = resolution, raw = true, camera = campixel!)
-
     area = scene.px_area
-    grid_size = (get_height(env_node[]), get_width(env_node[]))
-    # tile_inds = 
-    grid_inds = CartesianIndices(grid_size)
+
+    height = get_height(env_node[])
+    width = get_width(env_node[])
+
+    tile_inds = CartesianIndices((height, width))
     tile_size = @lift((widths($area)[1] / get_height($env_node), widths($area)[2] / get_width($env_node)))
+    @show tile_size.val
+
     transform = get_transform(get_height(env_node[]))
-    boxes(pos, tile_size) = [FRect2D((transform(p).I .- (1,1)) .* tile_size, tile_size) for p in pos]
-    centers(pos, tile_size) = [(transform(p).I .- (0.5,0.5)) .* tile_size for p in pos]
+    boxes(pos, tile_size) = [FRect2D((transform(p).I .- (1,1)) .* reverse(tile_size), reverse(tile_size)) for p in pos]
+    centers(pos, tile_size) = [(transform(p).I .- (0.5,0.5)) .* reverse(tile_size) for p in pos]
 
     # 1. paint background
     poly!(scene, area)
 
     # 2. paint each kind of object
-    for o in get_objects(env_node[])
-        if o !== EMPTY
-            scatter!(scene, @lift(centers(findall($env_node.world[o,:,:]), $tile_size)), color=get_color(o), marker=get_char(o), markersize=@lift(minimum($tile_size)))
-        end
+    for object in get_objects(env_node[])
+        scatter!(scene, @lift(centers(findall($env_node.world[object, :, :]), $tile_size)), color = get_color(object), marker = get_char(object), markersize = @lift(get_markersize(object, $tile_size)))
     end
 
-    # 3. paint stroke
-    poly!(scene, @lift(boxes(vec(grid_inds), $tile_size)), color=:transparent, strokecolor = :lightgray, strokewidth = 4)
-
     # 3. paint agent's view
-    view_boxes = @lift boxes([p for p in get_agent_view_inds($env_node) if p ∈ grid_inds], $tile_size)
-    poly!(scene, view_boxes, color="rgba(255,255,255,0.2)")
+    view_boxes = @lift(boxes([p for p in get_agent_view_inds($env_node) if p ∈ tile_inds], $tile_size))
+    poly!(scene, view_boxes, color = "rgba(255,255,255,0.2)")
 
     # 4. paint agent
     agent = @lift(get_agent($env_node))
-    agent_position = @lift((transform(get_agent_pos($env_node)).I .- (0.5, 0.5)).* $tile_size)
-    scatter!(scene, agent_position, color=@lift(get_color($agent)), marker=@lift(get_char($agent)), markersize=@lift(minimum($tile_size)))
+    agent_center = @lift(centers([get_agent_pos($env_node)], $tile_size)[1])
+    scatter!(scene, agent_center, color = @lift(get_color($agent)), marker = @lift(get_char($agent)), markersize = @lift(get_markersize($agent, $tile_size)))
 
     display(scene)
     scene

--- a/src/makie_rendering.jl
+++ b/src/makie_rendering.jl
@@ -9,7 +9,7 @@ get_box(pos, tile_size, transform) = FRect2D((transform(pos).I .- (1,1)) .* reve
 get_markersize(object::AbstractObject, tile_size) = reverse(tile_size)
 get_markersize(object::Empty, tile_size) = reverse(tile_size) ./ 5
 
-function init_screen(env_node::Observable{<:AbstractGridWorld}; resolution = (720, 480))
+function init_screen(env_node::Observable{<:AbstractGridWorld}; resolution = (720, 720))
     scene = Scene(resolution = resolution, raw = true, camera = campixel!)
 
     height = get_height(env_node[])

--- a/src/makie_rendering.jl
+++ b/src/makie_rendering.jl
@@ -49,6 +49,8 @@ function play(env::AbstractGridWorld;file_name=nothing,frame_rate=24)
     ←: TurnLeft
     →: TurnRight
     ↑: MoveForward
+    p: Pickup
+    r: reset!
     q: Quit
     """)
     env_node = Node(env)
@@ -69,6 +71,12 @@ function play(env::AbstractGridWorld;file_name=nothing,frame_rate=24)
             env_node[] = env
         elseif ispressed(b, Keyboard.up)
             env(MOVE_FORWARD)
+            env_node[] = env
+        elseif ispressed(b, Keyboard.p)
+            env(PICK_UP)
+            env_node[] = env
+        elseif ispressed(b, Keyboard.r)
+            reset!(env)
             env_node[] = env
         elseif ispressed(b, Keyboard.q)
             is_quit[] = true

--- a/src/terminal_rendering.jl
+++ b/src/terminal_rendering.jl
@@ -3,6 +3,19 @@ using Crayons
 get_background(env::AbstractGridWorld, pos::CartesianIndex{2}, ::Val{:agent_view}) = :dark_gray
 get_background(env::AbstractGridWorld, pos::CartesianIndex{2}, ::Val{:full_view}) = pos in get_agent_view_inds(env) ? :dark_gray : :black
 
+get_color(::Nothing) = :white
+get_char(::Nothing) = '~'
+
+function get_first_object(world::GridWorldBase, pos::CartesianIndex)
+    objects = get_objects(world)
+    idx = findfirst(world[:, pos])
+    if isnothing(idx)
+        return nothing
+    else
+        return objects[idx]
+    end
+end
+
 function print_grid(io::IO, env::AbstractGridWorld, view_type)
     world = get_world_with_agent(env, view_type = view_type)
     objects = get_objects(world)
@@ -10,17 +23,8 @@ function print_grid(io::IO, env::AbstractGridWorld, view_type)
     for i in 1:get_height(world)
         for j in 1:get_width(world)
             pos = CartesianIndex(i, j)
-            idx = findfirst(world[:, pos])
-            if isnothing(idx)
-                object = nothing
-                foreground = :white
-                char = '_'
-            else
-                object = objects[idx]
-                foreground = get_color(object)
-                char = get_char(object)
-            end
-            print(io, Crayon(background = get_background(env, pos, Val{view_type}()), foreground = foreground, bold = true, reset = true), char)
+            object = get_first_object(world, pos)
+            print(io, Crayon(background = get_background(env, pos, Val{view_type}()), foreground = get_color(object), bold = true, reset = true), get_char(object))
         end
         println(io, Crayon(reset = true))
     end


### PR DESCRIPTION
1. Refactor terminal rendering.
1. Refactor `Makie` rendering.
    1. Some bug fixes
    1. Allow rendering rectangular dimensional worlds
    1. Adaptive tile sizes during resizing of `Makie` window
    1. Add keys for `Pickup` (p) and `reset!` (r) during interactive rendering
    1. Make `Makie` rendering appear more consistent with the terminal rendering
    1. Increase code readability
1. Allow rectangular dimensions for `EmptyGridWorld` (#70 ). Mainly for testing `Makie` rendering for rectangular worlds.
1. Big fix in `DoorKey` environment. Empty the agent's inventory inside `reset!` method.