### PR TITLE
Fix and Test

### DIFF
--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -97,16 +97,17 @@ function RLBase.reset!(env::DynamicObstacles; agent_start_pos = CartesianIndex(2
     world[GOAL, goal_pos] = true
     world[EMPTY, goal_pos] = false
 
+    env.obstacle_pos = Array{CartesianIndex{2}, 1}[]
     obstacles_placed = 0
     while obstacles_placed < env.num_obstacles
         pos = CartesianIndex(rand(rng, 2:n-1), rand(rng, 2:n-1))
-        if (pos == get_agent_pos(env)) || (world[OBSTACLE, pos] == true) || (pos == goal_pos)
+        if (pos == agent_start_pos) || (world[OBSTACLE, pos] == true) || (pos == goal_pos)
             continue
         else
             world[OBSTACLE, pos] = true
             world[EMPTY, pos] = false
-            obstacles_placed = obstacles_placed + 1
-            env.obstacle_pos[obstacles_placed] = pos
+            obstacles_placed += 1
+            push!(env.obstacle_pos, pos)
         end
     end
 

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -55,10 +55,11 @@ end
 #####
 
 function RLBase.reset!(env::AbstractGridWorld; agent_start_dir = RIGHT)
-    world = get_world(env)
-    rng = get_rng(env)
+    big_n = 2 * env.num_rooms * env.room_length_range.stop
+    world = GridWorldBase(get_objects(env), big_n, big_n)
+    set_world!(env, world)
 
-    world[:, :, :] .= false
+    rng = get_rng(env)
 
     env.rooms = Room[]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,9 +23,7 @@ ENVS_RLBASE = [EmptyGridWorld, FourRooms, GoToDoor, DoorKey, CollectGems, Dynami
                 @test get_world(env)[WALL, get_agent_pos(env)] == false
                 view = get_agent_view(env)
                 @test typeof(view) <: BitArray{3}
-                @test size(view,1) == length(get_objects(env))
-                @test size(view,2) == 7
-                @test size(view,3) == 7
+                @test size(view, 1) == length(get_objects(env))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,58 +3,49 @@ using Test
 using Random
 using ReinforcementLearningBase
 
-ENVS = [EmptyGridWorld, FourRooms, GoToDoor, DoorKey, CollectGems, DynamicObstacles, SequentialRooms]
-ENVS_RLBASE = [EmptyGridWorld, FourRooms, GoToDoor, DoorKey, CollectGems, DynamicObstacles, SequentialRooms]
+ENVS = [EmptyGridWorld, FourRooms, SequentialRooms, GoToDoor, DoorKey, CollectGems, DynamicObstacles]
+
+MAX_STEPS = 3000
+NUM_RESETS = 3
+
+get_terminal_rewards(env::Union{EmptyGridWorld, FourRooms, SequentialRooms, DoorKey}) = (env.goal_reward,)
+get_terminal_rewards(env::DynamicObstacles) = (env.goal_reward, env.obstacle_reward)
+get_terminal_rewards(env::CollectGems) = (env.num_gem_init * env.gem_reward,)
+get_terminal_rewards(env::GoToDoor) = (env.target_reward, env.penalty)
 
 @testset "GridWorlds.jl" begin
     for Env in ENVS
         @testset "$(Env)" begin
             env = Env()
-            @test typeof(get_agent_pos(env)) == CartesianIndex{2}
-            @test typeof(get_agent_dir(env)) <: Direction
-            @test size(get_grid(env), 1) == length(get_objects(env))
+            for _ in 1:NUM_RESETS
+                reset!(env)
+                @test get_reward(env) == 0.0
+                @test get_terminal(env) == false
+                if Env == GoToDoor
+                    @test get_state(env) == (get_agent_view(env), env.target)
+                else
+                    @test get_state(env) == get_agent_view(env)
+                end
 
-            for _=1:1000
-                env = env(rand(get_actions(env)))
-                @test 1 ≤ get_agent_pos(env)[1] ≤ get_height(env)
-                @test 1 ≤ get_agent_pos(env)[2] ≤ get_width(env)
-                @test get_world(env)[WALL, get_agent_pos(env)] == false
-                view = get_agent_view(env)
-                @test typeof(view) <: BitArray{3}
-                @test size(view, 1) == length(get_objects(env))
-            end
-        end
-    end
+                total_reward = 0.0
+                for i in 1:MAX_STEPS
+                    action = rand(get_actions(env))
+                    env(action)
+                    total_reward += get_reward(env)
 
-    for Env in ENVS_RLBASE
-        @testset "$(Env) RLBase API" begin
-            env = Env()
+                    @test 1 ≤ get_agent_pos(env)[1] ≤ get_height(env)
+                    @test 1 ≤ get_agent_pos(env)[2] ≤ get_width(env)
+                    @test get_world(env)[WALL, get_agent_pos(env)] == false
 
-            @test get_reward(env) == 0.0
-            @test get_terminal(env) == false
-            if Env == GoToDoor
-                @test get_state(env) == (get_agent_view(env), env.target)
-            else
-                @test get_state(env) == get_agent_view(env)
-            end
+                    if get_terminal(env)
+                        @test total_reward in get_terminal_rewards(env)
+                        break
+                    end
 
-            π = RandomPolicy(env)
-            total_reward = 0.0
-
-            while !get_terminal(env)
-                action = π(env)
-                env(action)
-                total_reward += get_reward(env)
-            end
-
-            if Env == CollectGems
-                @test total_reward == env.num_gem_init * env.gem_reward
-            elseif Env == EmptyGridWorld || Env == FourRooms || Env == DoorKey || Env == SequentialRooms
-                @test total_reward == env.goal_reward
-            elseif Env == GoToDoor
-                @test (total_reward == env.target_reward || total_reward == env.penalty)
-            elseif Env == DynamicObstacles
-                @test (total_reward == env.obstacle_reward || total_reward == env.goal_reward)
+                    if i == MAX_STEPS
+                        @info "$Env not terminated after MAX_STEPS = $MAX_STEPS"
+                    end
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,6 @@ ENVS_RLBASE = [EmptyGridWorld, FourRooms, GoToDoor, DoorKey, CollectGems, Dynami
             @test typeof(get_agent_pos(env)) == CartesianIndex{2}
             @test typeof(get_agent_dir(env)) <: Direction
             @test size(get_grid(env), 1) == length(get_objects(env))
-            @test 1 ≤ get_agent_pos(env)[1] ≤ get_height(env)
-            @test 1 ≤ get_agent_pos(env)[2] ≤ get_width(env)
 
             for _=1:1000
                 env = env(rand(get_actions(env)))


### PR DESCRIPTION
1. Bug fixes
    1. Fix `SequentialRooms`: Create and use the big world on each `reset!`
    1. Fix `DynamicObstacles`: Use `agent_start_pos` instead of `get_agent_pos(env)` to check while placing obstacles. This is because the agent pos is reset in the end of `reset!` method, and so `get_agent_pos(env)` would return the agent pos from the previous run.
1. Add some useful tests and remove unnecessary tests. Also, combined `RLBase` testset so that now there is only one testset corresponding to each environment.
