### PR TITLE
refactor terminal rendering

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -7,27 +7,19 @@ abstract type AbstractGridWorld <: AbstractEnv end
 get_world(env::AbstractGridWorld) = env.world
 set_world!(env::AbstractGridWorld, world::GridWorldBase) = env.world = world
 
-get_grid(env::AbstractGridWorld, ::Val{:full_view}) = env |> get_world |> get_grid
-get_grid(env::AbstractGridWorld, ::Val{:agent_view}) = get_agent_view(env)
-get_grid(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_grid(env, Val{view_type}())
-
+get_grid(env::AbstractGridWorld) = env |> get_world |> get_grid
 get_objects(env::AbstractGridWorld) = env |> get_world |> get_objects
 
 get_num_objects(env::AbstractGridWorld) = env |> get_world |> get_num_objects
 get_height(env::AbstractGridWorld) = env |> get_world |> get_height
 get_width(env::AbstractGridWorld) = env |> get_world |> get_width
 
-get_agent(env::AbstractGridWorld, ::Val{:full_view}) = env.agent
-get_agent(env::AbstractGridWorld, ::Val{:agent_view}) = Agent(dir = DOWN, pos = CartesianIndex(1, size(get_grid(env, Val{:agent_view}()), 3) ÷ 2 + 1))
-get_agent(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_agent(env, Val{view_type}())
+get_agent(env::AbstractGridWorld) = env.agent
 set_agent!(env::AbstractGridWorld, agent::Agent) = env.agent = agent
-
-get_agent_pos(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_pos(get_agent(env, Val{view_type}()))
+get_agent_pos(env::AbstractGridWorld) = env |> get_agent |> get_pos
 set_agent_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = set_pos!(get_agent(env), pos)
-
-get_agent_dir(env::AbstractGridWorld; view_type::Symbol = :full_view) = get_dir(get_agent(env, Val{view_type}()))
+get_agent_dir(env::AbstractGridWorld) = env |> get_agent |> get_dir
 set_agent_dir!(env::AbstractGridWorld, dir::Direction) = set_dir!(get_agent(env), dir)
-
 get_inventory_type(env::AbstractGridWorld) = env |> get_agent |> get_inventory_type
 get_inventory(env::AbstractGridWorld) = env |> get_agent |> get_inventory
 set_inventory!(env::AbstractGridWorld, item) = set_inventory!(get_agent(env), item)


### PR DESCRIPTION
1. Remove unnecessary methods from `abstract_grid_world.jl` and move some of those methods to `terminal_rendering.jl` that are only relevant to terminal rendering.
1. Remove method `get_world_with_agent`. Keep things simple.