### PR TITLE
Cleanup

### DIFF
--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -4,7 +4,7 @@ export GW
 
 import Requires
 import Crayons
-import MacroTools
+import MacroTools:@forward
 using Random
 using ReinforcementLearningBase
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -6,13 +6,7 @@ abstract type AbstractGridWorld <: AbstractEnv end
 
 get_world(env::AbstractGridWorld) = env.world
 set_world!(env::AbstractGridWorld, world::GridWorldBase) = env.world = world
-
-get_grid(env::AbstractGridWorld) = env |> get_world |> get_grid
-get_objects(env::AbstractGridWorld) = env |> get_world |> get_objects
-
-get_num_objects(env::AbstractGridWorld) = env |> get_world |> get_num_objects
-get_height(env::AbstractGridWorld) = env |> get_world |> get_height
-get_width(env::AbstractGridWorld) = env |> get_world |> get_width
+@forward AbstractGridWorld.world get_grid, get_objects, get_num_objects, get_height, get_width
 
 get_agent(env::AbstractGridWorld) = env.agent
 set_agent!(env::AbstractGridWorld, agent::Agent) = env.agent = agent
@@ -20,9 +14,7 @@ get_agent_pos(env::AbstractGridWorld) = env |> get_agent |> get_pos
 set_agent_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = set_pos!(get_agent(env), pos)
 get_agent_dir(env::AbstractGridWorld) = env |> get_agent |> get_dir
 set_agent_dir!(env::AbstractGridWorld, dir::Direction) = set_dir!(get_agent(env), dir)
-get_inventory_type(env::AbstractGridWorld) = env |> get_agent |> get_inventory_type
-get_inventory(env::AbstractGridWorld) = env |> get_agent |> get_inventory
-set_inventory!(env::AbstractGridWorld, item) = set_inventory!(get_agent(env), item)
+@forward AbstractGridWorld.agent get_inventory_type, get_inventory, set_inventory!
 
 set_reward!(env::AbstractGridWorld, reward) = env.reward = reward
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -4,6 +4,10 @@ export set_world!, set_agent!, set_agent_pos!, set_agent_dir!, set_reward!
 
 abstract type AbstractGridWorld <: AbstractEnv end
 
+#####
+# Useful getters and setters
+#####
+
 get_world(env::AbstractGridWorld) = env.world
 set_world!(env::AbstractGridWorld, world::GridWorldBase) = env.world = world
 @forward AbstractGridWorld.world get_grid, get_objects, get_num_objects, get_height, get_width
@@ -23,6 +27,10 @@ get_rng(env::AbstractGridWorld) = env.rng
 get_goal_pos(env::AbstractGridWorld) = env.goal_pos
 set_goal_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = env.goal_pos = pos
 
+#####
+# Agent's view
+#####
+
 function get_agent_view(env::AbstractGridWorld, agent_view_size = (7,7))
     world = get_world(env)
     agent_view = BitArray{3}(undef, get_num_objects(env), agent_view_size...)
@@ -33,6 +41,10 @@ end
 get_agent_view_inds(env::AbstractGridWorld, agent_view_size = (7,7)) = get_agent_view_inds(get_agent_pos(env).I, agent_view_size, get_agent_dir(env))
 
 get_agent_view!(grid::BitArray{3}, env::AbstractGridWorld) = get_agent_view!(grid, get_world(env), get_agent_pos(env), get_agent_dir(env))
+
+#####
+# Full view
+#####
 
 function get_agent_layer(grid::BitArray{3}, agent_pos::CartesianIndex{2})
     dims = size(grid)[2:end]

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,5 +1,5 @@
 export AbstractGridWorld
-export get_world, get_grid, get_objects, get_num_objects, get_height, get_width, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_agent_view!, get_full_view
+export get_world, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_agent_view!, get_full_view
 export set_world!, set_agent!, set_agent_pos!, set_agent_dir!, set_reward!
 
 abstract type AbstractGridWorld <: AbstractEnv end

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -32,9 +32,7 @@ set_goal_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = env.goal_pos = p
 #####
 
 function get_agent_view(env::AbstractGridWorld, agent_view_size = (7,7))
-    world = get_world(env)
-    agent_view = BitArray{3}(undef, get_num_objects(env), agent_view_size...)
-    fill!(agent_view, false)
+    agent_view = falses(get_num_objects(env), agent_view_size...)
     get_agent_view!(agent_view, env)
 end
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -39,34 +39,6 @@ Base.getindex(world::GridWorldBase, object::AbstractObject, args...) = getindex(
 Base.setindex!(world::GridWorldBase, value::Bool, object::AbstractObject, args...) = setindex!(get_grid(world), value, Base.to_index(world, object), args...)
 
 #####
-# utils
-#####
-
-switch!(world::GridWorldBase, x, src::CartesianIndex{2}, dest::CartesianIndex{2}) = world[x, src], world[x, dest] = world[x, dest], world[x, src]
-
-function switch!(world::GridWorldBase, src::CartesianIndex{2}, dest::CartesianIndex{2})
-    for x in axes(world, 1)
-        switch!(world, x, src, dest)
-    end
-end
-
-function Random.rand(rng::AbstractRNG, f::Function, inds::Union{Vector{CartesianIndex{2}}, CartesianIndices{2}}; max_try::Int = 1000)
-    for _ in 1:max_try
-        pos = rand(rng, inds)
-        if f(pos)
-            return pos
-        end
-    end
-    @warn "number of tries exceeded max_try = $max_try"
-    return nothing
-end
-
-function Random.rand(rng::AbstractRNG, f::Function, world::GridWorldBase; max_try = 1000)
-    inds = CartesianIndices((get_height(world), get_width(world)))
-    rand(rng, f, inds, max_try = max_try)
-end
-
-#####
 # get_agent_view
 #####
 
@@ -91,4 +63,24 @@ function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{
         end
     end
     return agent_view
+end
+
+#####
+# utils
+#####
+
+function Random.rand(rng::AbstractRNG, f::Function, inds::Union{Vector{CartesianIndex{2}}, CartesianIndices{2}}; max_try::Int = 1000)
+    for _ in 1:max_try
+        pos = rand(rng, inds)
+        if f(pos)
+            return pos
+        end
+    end
+    @warn "number of tries exceeded max_try = $max_try"
+    return nothing
+end
+
+function Random.rand(rng::AbstractRNG, f::Function, world::GridWorldBase; max_try = 1000)
+    inds = CartesianIndices((get_height(world), get_width(world)))
+    rand(rng, f, inds, max_try = max_try)
 end

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -25,9 +25,9 @@ get_num_objects(grid::BitArray{3}) = size(grid, 1)
 get_height(grid::BitArray{3}) = size(grid, 2)
 get_width(grid::BitArray{3}) = size(grid, 3)
 
-MacroTools.@forward GridWorldBase.grid get_num_objects, get_height, get_width
+@forward GridWorldBase.grid get_num_objects, get_height, get_width
 
-MacroTools.@forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
+@forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
 
 @generated function Base.to_index(::GridWorldBase{O}, object::X) where {X<:AbstractObject, O}
     i = findfirst(X .=== O.parameters)

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -50,10 +50,10 @@ Base.setindex!(world::GridWorldBase, value::Bool, object::AbstractObject, args..
 # get_agent_view
 #####
 
-get_agent_view_inds((i, j), (m, n), ::Left) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j-m+1:j))
-get_agent_view_inds((i, j), (m, n), ::Right) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j:j+m-1))
 get_agent_view_inds((i, j), (m, n), ::Up) = CartesianIndices((i-m+1:i, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
 get_agent_view_inds((i, j), (m, n), ::Down) = CartesianIndices((i:i+m-1, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
+get_agent_view_inds((i, j), (m, n), ::Left) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j-m+1:j))
+get_agent_view_inds((i, j), (m, n), ::Right) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j:j+m-1))
 
 ind_map((i,j), (m, n), ::Up) = (m-i+1, n-j+1)
 ind_map((i,j), (m, n), ::Down) = (i,j)
@@ -65,11 +65,13 @@ function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{
     grid_size = (get_height(grid), get_width(grid))
     inds = get_agent_view_inds(agent_pos.I, view_size, dir)
     valid_inds = CartesianIndices(grid_size)
+
     for ind in CartesianIndices(inds)
         if inds[ind] ∈ valid_inds
             agent_view[:, ind_map(ind.I, view_size, dir)...] .= grid[:, inds[ind]]
         end
     end
+
     return agent_view
 end
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -35,12 +35,8 @@ get_width(grid::BitArray{3}) = size(grid, 3)
     :($i)
 end
 
-Base.getindex(world::GridWorldBase, object::AbstractObject, height::Int, width::Int) = getindex(get_grid(world), Base.to_index(world, object), height, width)
-Base.getindex(world::GridWorldBase, object::AbstractObject, pos::CartesianIndex{2}) = getindex(world, object, pos[1], pos[2])
-Base.getindex(world::GridWorldBase, object::AbstractObject, heights::Colon, widths::Colon) = getindex(get_grid(world), Base.to_index(world, object), heights, widths)
-
-Base.setindex!(world::GridWorldBase, ispresent::Bool, object::AbstractObject, height::Int, width::Int) = setindex!(get_grid(world), ispresent, Base.to_index(world, object), height, width)
-Base.setindex!(world::GridWorldBase, ispresent::Bool, object::AbstractObject, pos::CartesianIndex{2}) = setindex!(world, ispresent, object, pos[1], pos[2])
+Base.getindex(world::GridWorldBase, object::AbstractObject, args...) = getindex(get_grid(world), Base.to_index(world, object), args...)
+Base.setindex!(world::GridWorldBase, value::Bool, object::AbstractObject, args...) = setindex!(get_grid(world), value, Base.to_index(world, object), args...)
 
 #####
 # utils

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,6 +1,10 @@
 export GridWorldBase
 export get_grid, get_objects, get_num_objects, get_height, get_width, switch!, get_agent_view!
 
+#####
+# GridWorldBase
+#####
+
 """
     GridWorldBase{O} <: AbstractArray{Bool, 3}
 
@@ -26,6 +30,10 @@ get_height(grid::BitArray{3}) = size(grid, 2)
 get_width(grid::BitArray{3}) = size(grid, 3)
 
 @forward GridWorldBase.grid get_num_objects, get_height, get_width
+
+#####
+# Indexing of GridWorldBase objects
+#####
 
 @forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -26,9 +26,7 @@ get_num_objects(grid::BitArray{3}) = size(grid, 1)
 get_height(grid::BitArray{3}) = size(grid, 2)
 get_width(grid::BitArray{3}) = size(grid, 3)
 
-get_num_objects(world::GridWorldBase) = world |> get_grid |> get_num_objects
-get_height(world::GridWorldBase) = world |> get_grid |> get_height
-get_width(world::GridWorldBase) = world |> get_grid |> get_width
+MacroTools.@forward GridWorldBase.grid get_num_objects, get_height, get_width
 
 MacroTools.@forward GridWorldBase.grid Base.size, Base.getindex, Base.setindex!
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -14,8 +14,7 @@ struct GridWorldBase{O} <: AbstractArray{Bool, 3}
 end
 
 function GridWorldBase(objects::Tuple{Vararg{AbstractObject}}, height::Int, width::Int)
-    grid = BitArray{3}(undef, length(objects), height, width)
-    fill!(grid, false)
+    grid = falses(length(objects), height, width)
     GridWorldBase(grid, objects)
 end
 


### PR DESCRIPTION
1. Simplify `GridWorldBase` indexing
1. Remove the `switch!` method.
1. `import MacroTools:@forward` and use it wherever appropriate
1.  Use the `falses` method wherever appropriate.
1. Cleanup exports
1. Miscellaneous cleanup