### PR TITLE
Update RLBase 0.9.0 and bump GridWorlds version to 0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Crayons = "4.0"
 MacroTools = "0.5"
 Requires = "1.1"
-ReinforcementLearningBase = "0.8.5"
+ReinforcementLearningBase = "0.9"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridWorlds"
 uuid = "e15a9946-cd7f-4d03-83e2-6c30bacb0043"
 authors = ["Sriram"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -79,7 +79,8 @@ RLBase.action_space(env::AbstractGridWorld, ::DefaultPlayer) = (MOVE_FORWARD, TU
 const get_reward = RLBase.reward
 RLBase.reward(env::AbstractGridWorld, ::DefaultPlayer) = env.reward
 
-RLBase.get_terminal(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
+const get_terminal = RLBase.is_terminated
+RLBase.is_terminated(env::AbstractGridWorld, ::DefaultPlayer) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
     dir = get_agent_dir(env)

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -79,7 +79,6 @@ RLBase.action_space(env::AbstractGridWorld, ::DefaultPlayer) = (MOVE_FORWARD, TU
 const get_reward = RLBase.reward
 RLBase.reward(env::AbstractGridWorld, ::DefaultPlayer) = env.reward
 
-const get_terminal = RLBase.is_terminated
 RLBase.is_terminated(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
@@ -101,7 +100,7 @@ function (env::AbstractGridWorld)(::MoveForward)
     end
 
     set_reward!(env, 0.0)
-    if get_terminal(env)
+    if is_terminated(env)
         set_reward!(env, env.terminal_reward)
     end
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -69,11 +69,9 @@ end
 # RLBase API defaults
 #####
 
-RLBase.DefaultStateStyle(env::AbstractGridWorld) = RLBase.PartialObservation{Array}()
-
-RLBase.get_state(env::AbstractGridWorld, ::RLBase.PartialObservation{Array}, args...) = get_agent_view(env)
-
-RLBase.get_state(env::AbstractGridWorld, ::RLBase.Observation{Array}, args...) = (get_full_view(env), get_agent_dir(env))
+const get_state = RLBase.state
+RLBase.state(env::AbstractGridWorld, ::RLBase.Observation, ::DefaultPlayer) = get_agent_view(env)
+RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::DefaultPlayer) = (get_full_view(env), get_agent_dir(env))
 
 RLBase.get_actions(env::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -73,7 +73,7 @@ const get_state = RLBase.state
 RLBase.state(env::AbstractGridWorld, ::RLBase.Observation, ::DefaultPlayer) = get_agent_view(env)
 RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::DefaultPlayer) = (get_full_view(env), get_agent_dir(env))
 
-const get_actions = RLBase.action_space
+const get_action_space = RLBase.action_space
 RLBase.action_space(env::AbstractGridWorld, ::DefaultPlayer) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 
 const get_reward = RLBase.reward

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -80,7 +80,7 @@ const get_reward = RLBase.reward
 RLBase.reward(env::AbstractGridWorld, ::DefaultPlayer) = env.reward
 
 const get_terminal = RLBase.is_terminated
-RLBase.is_terminated(env::AbstractGridWorld, ::DefaultPlayer) = get_world(env)[GOAL, get_agent_pos(env)]
+RLBase.is_terminated(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
 
 function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
     dir = get_agent_dir(env)

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -73,7 +73,8 @@ const get_state = RLBase.state
 RLBase.state(env::AbstractGridWorld, ::RLBase.Observation, ::DefaultPlayer) = get_agent_view(env)
 RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::DefaultPlayer) = (get_full_view(env), get_agent_dir(env))
 
-RLBase.get_actions(env::AbstractGridWorld) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
+const get_actions = RLBase.action_space
+RLBase.action_space(env::AbstractGridWorld, ::DefaultPlayer) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 
 RLBase.get_reward(env::AbstractGridWorld) = env.reward
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -76,7 +76,8 @@ RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::DefaultPlayer) = 
 const get_actions = RLBase.action_space
 RLBase.action_space(env::AbstractGridWorld, ::DefaultPlayer) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 
-RLBase.get_reward(env::AbstractGridWorld) = env.reward
+const get_reward = RLBase.reward
+RLBase.reward(env::AbstractGridWorld, ::DefaultPlayer) = env.reward
 
 RLBase.get_terminal(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
 

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -30,7 +30,7 @@ function CollectGems(; height = 8, width = 8, num_gem_init = floor(Int, sqrt(hei
     return env
 end
 
-RLBase.get_terminal(env::CollectGems) = env.num_gem_current <= 0
+RLBase.is_terminated(env::CollectGems) = env.num_gem_current <= 0
 
 function (env::CollectGems)(::MoveForward)
     dir = get_agent_dir(env)

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -54,7 +54,7 @@ function (env::DoorKey)(::MoveForward)
     end
 
     set_reward!(env, 0.0)
-    if get_terminal(env)
+    if is_terminated(env)
         set_reward!(env, env.terminal_reward)
     end
 

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -33,7 +33,7 @@ function DoorKey(; height = 7, width = 7, rng = Random.GLOBAL_RNG)
     return env
 end
 
-RLBase.get_actions(env::DoorKey) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, PICK_UP)
+RLBase.action_space(env::DoorKey) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, PICK_UP)
 
 function (env::DoorKey)(::MoveForward)
     objects = get_objects(env)

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -91,7 +91,7 @@ function update_obstacles!(env::DynamicObstacles)
     return env
 end
 
-RLBase.get_terminal(env::DynamicObstacles) = iscollision(env) || env[GOAL, get_agent_pos(env)]
+RLBase.is_terminated(env::DynamicObstacles) = iscollision(env) || env[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::DynamicObstacles)
     rng = get_rng(env)

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -36,9 +36,9 @@ function GoToDoor(; height = 8, width = 8, rng = Random.GLOBAL_RNG)
     return env
 end
 
-RLBase.get_state(env::GoToDoor) = (get_agent_view(env), env.target)
+RLBase.state(env::GoToDoor) = (get_agent_view(env), env.target)
 
-RLBase.get_terminal(env::GoToDoor) = get_agent_pos(env) in values(env.door_pos)
+RLBase.is_terminated(env::GoToDoor) = get_agent_pos(env) in values(env.door_pos)
 
 function (env::GoToDoor)(::MoveForward)
     dir = get_agent_dir(env)

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -48,7 +48,7 @@ function (env::GoToDoor)(::MoveForward)
     end
 
     set_reward!(env, 0.0)
-    if get_terminal(env)
+    if is_terminated(env)
         if env[env.target, get_agent_pos(env)]
             set_reward!(env, env.terminal_reward)
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,25 +19,25 @@ get_terminal_rewards(env::GoToDoor) = (env.terminal_reward, env.terminal_penalty
             env = Env()
             for _ in 1:NUM_RESETS
                 reset!(env)
-                @test get_reward(env) == 0.0
-                @test get_terminal(env) == false
+                @test reward(env) == 0.0
+                @test is_terminated(env) == false
                 if Env == GoToDoor
-                    @test get_state(env) == (get_agent_view(env), env.target)
+                    @test state(env) == (get_agent_view(env), env.target)
                 else
-                    @test get_state(env) == get_agent_view(env)
+                    @test state(env) == get_agent_view(env)
                 end
 
                 total_reward = 0.0
                 for i in 1:MAX_STEPS
-                    action = rand(get_actions(env))
+                    action = rand(action_space(env))
                     env(action)
-                    total_reward += get_reward(env)
+                    total_reward += reward(env)
 
                     @test 1 ≤ get_agent_pos(env)[1] ≤ get_height(env)
                     @test 1 ≤ get_agent_pos(env)[2] ≤ get_width(env)
                     @test get_world(env)[WALL, get_agent_pos(env)] == false
 
-                    if get_terminal(env)
+                    if is_terminated(env)
                         @test total_reward in get_terminal_rewards(env)
                         break
                     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,13 @@ ENVS = [EmptyRoom, GridRooms, SequentialRooms, GoToDoor, DoorKey, CollectGems, D
 MAX_STEPS = 3000
 NUM_RESETS = 3
 
-get_terminal_rewards(env::Union{EmptyRoom, GridRooms, SequentialRooms, DoorKey}) = (env.terminal_reward,)
-get_terminal_rewards(env::DynamicObstacles) = (env.terminal_reward, env.terminal_penalty)
-get_terminal_rewards(env::CollectGems) = (env.num_gem_init * env.gem_reward,)
+get_terminal_rewards(env::EmptyRoom) = (env.terminal_reward,)
+get_terminal_rewards(env::GridRooms) = (env.terminal_reward,)
+get_terminal_rewards(env::SequentialRooms) = (env.terminal_reward,)
 get_terminal_rewards(env::GoToDoor) = (env.terminal_reward, env.terminal_penalty)
+get_terminal_rewards(env::DoorKey) = (env.terminal_reward,)
+get_terminal_rewards(env::CollectGems) = (env.num_gem_init * env.gem_reward,)
+get_terminal_rewards(env::DynamicObstacles) = (env.terminal_reward, env.terminal_penalty)
 
 @testset "GridWorlds.jl" begin
     for Env in ENVS


### PR DESCRIPTION
1. Update `RLBase` version to `0.9.0`
    1. `get_terminal` changed to `is_terminated`
    2. `get_actions` changed to `get_action_space`
    3. add consts `get_state` and `get_reward`
1. Bump `GridWorlds` version to `0.2.0`
1. In tests, split the `get_terminal_rewards` method for each env type.