### PR TITLE
Refactor and Cleanup

### DIFF
--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -5,7 +5,7 @@ export GW
 import Requires
 import Crayons
 import MacroTools:@forward
-using Random
+import Random
 using ReinforcementLearningBase
 
 const GW = GridWorlds

--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -6,7 +6,8 @@ import Requires
 import Crayons
 import MacroTools:@forward
 import Random
-using ReinforcementLearningBase
+import ReinforcementLearningBase
+import ReinforcementLearningBase:RLBase
 
 const GW = GridWorlds
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,6 +1,4 @@
 export AbstractGridWorld
-export get_world, get_agent, get_agent_pos, get_agent_dir, get_agent_view, get_agent_view!, get_full_view
-export set_world!, set_agent!, set_agent_pos!, set_agent_dir!, set_reward!
 
 abstract type AbstractGridWorld <: AbstractEnv end
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -94,7 +94,7 @@ function (env::AbstractGridWorld)(::MoveForward)
     world = get_world(env)
 
     dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
+    dest = move(dir, get_agent_pos(env))
     if !world[WALL, dest]
         set_agent_pos!(env, dest)
     end

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -10,7 +10,7 @@ abstract type AbstractGridWorld <: AbstractEnv end
 
 get_world(env::AbstractGridWorld) = env.world
 set_world!(env::AbstractGridWorld, world::GridWorldBase) = env.world = world
-@forward AbstractGridWorld.world get_grid, get_objects, get_num_objects, get_height, get_width, Base.size, Base.getindex, Base.setindex!
+@forward AbstractGridWorld.world get_grid, get_objects, get_num_objects, get_height, get_width
 
 get_agent(env::AbstractGridWorld) = env.agent
 set_agent!(env::AbstractGridWorld, agent::Agent) = env.agent = agent

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,6 +1,6 @@
 export AbstractGridWorld
 
-abstract type AbstractGridWorld <: AbstractEnv end
+abstract type AbstractGridWorld <: RLBase.AbstractEnv end
 
 #####
 # Useful getters and setters
@@ -68,14 +68,14 @@ end
 #####
 
 const get_state = RLBase.state
-RLBase.state(env::AbstractGridWorld, ::RLBase.Observation, ::DefaultPlayer) = get_agent_view(env)
-RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::DefaultPlayer) = (get_full_view(env), get_agent_dir(env))
+RLBase.state(env::AbstractGridWorld, ::RLBase.Observation, ::RLBase.DefaultPlayer) = get_agent_view(env)
+RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::RLBase.DefaultPlayer) = (get_full_view(env), get_agent_dir(env))
 
 const get_action_space = RLBase.action_space
-RLBase.action_space(env::AbstractGridWorld, ::DefaultPlayer) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
+RLBase.action_space(env::AbstractGridWorld, ::RLBase.DefaultPlayer) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT)
 
 const get_reward = RLBase.reward
-RLBase.reward(env::AbstractGridWorld, ::DefaultPlayer) = env.reward
+RLBase.reward(env::AbstractGridWorld, ::RLBase.DefaultPlayer) = env.reward
 
 RLBase.is_terminated(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_pos(env)]
 
@@ -99,7 +99,7 @@ function (env::AbstractGridWorld)(::MoveForward)
     end
 
     set_reward!(env, 0.0)
-    if is_terminated(env)
+    if RLBase.is_terminated(env)
         set_reward!(env, env.terminal_reward)
     end
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -17,7 +17,7 @@ set_agent!(env::AbstractGridWorld, agent::Agent) = env.agent = agent
 get_agent_pos(env::AbstractGridWorld) = env |> get_agent |> get_pos
 set_agent_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = set_pos!(get_agent(env), pos)
 get_agent_dir(env::AbstractGridWorld) = env |> get_agent |> get_dir
-set_agent_dir!(env::AbstractGridWorld, dir::Direction) = set_dir!(get_agent(env), dir)
+set_agent_dir!(env::AbstractGridWorld, dir::AbstractDirection) = set_dir!(get_agent(env), dir)
 @forward AbstractGridWorld.agent get_inventory_type, get_inventory, set_inventory!
 
 set_reward!(env::AbstractGridWorld, reward) = env.reward = reward

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -83,7 +83,8 @@ RLBase.is_terminated(env::AbstractGridWorld) = get_world(env)[GOAL, get_agent_po
 
 function (env::AbstractGridWorld)(action::Union{TurnRight, TurnLeft})
     dir = get_agent_dir(env)
-    set_agent_dir!(env, action(dir))
+    new_dir = turn(action, dir)
+    set_agent_dir!(env, new_dir)
 
     set_reward!(env, 0.0)
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -25,7 +25,7 @@ get_rng(env::AbstractGridWorld) = env.rng
 get_goal_pos(env::AbstractGridWorld) = env.goal_pos
 set_goal_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = env.goal_pos = pos
 
-Random.rand(rng::AbstractRNG, f::Function, env::AbstractGridWorld; max_try = 1000) = rand(rng, f, get_world(env), max_try = max_try)
+Random.rand(rng::Random.AbstractRNG, f::Function, env::AbstractGridWorld; max_try = 1000) = rand(rng, f, get_world(env), max_try = max_try)
 
 #####
 # Agent's view

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -25,18 +25,22 @@ const TURN_RIGHT = TurnRight()
 struct MoveUp <: AbstractGridWorldAction end
 const MOVE_UP = MoveUp()
 (::MoveUp)(p::CartesianIndex{2}) = UP(p)
+move(::MoveUp, pos::CartesianIndex{2}) = move(UP, pos)
 
 struct MoveDown <: AbstractGridWorldAction end
 const MOVE_DOWN = MoveDown()
 (::MoveDown)(p::CartesianIndex{2}) = DOWN(p)
+move(::MoveDown, pos::CartesianIndex{2}) = move(DOWN, pos)
 
 struct MoveLeft <: AbstractGridWorldAction end
 const MOVE_LEFT = MoveLeft()
 (::MoveLeft)(p::CartesianIndex{2}) = LEFT(p)
+move(::MoveLeft, pos::CartesianIndex{2}) = move(LEFT, pos)
 
 struct MoveRight <: AbstractGridWorldAction end
 const MOVE_RIGHT = MoveRight()
 (::MoveRight)(p::CartesianIndex{2}) = RIGHT(p)
+move(::MoveRight, pos::CartesianIndex{2}) = move(RIGHT, pos)
 
 struct PickUp <: AbstractGridWorldAction end
 const PICK_UP = PickUp()

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -24,22 +24,18 @@ const TURN_RIGHT = TurnRight()
 
 struct MoveUp <: AbstractGridWorldAction end
 const MOVE_UP = MoveUp()
-(::MoveUp)(p::CartesianIndex{2}) = UP(p)
 move(::MoveUp, pos::CartesianIndex{2}) = move(UP, pos)
 
 struct MoveDown <: AbstractGridWorldAction end
 const MOVE_DOWN = MoveDown()
-(::MoveDown)(p::CartesianIndex{2}) = DOWN(p)
 move(::MoveDown, pos::CartesianIndex{2}) = move(DOWN, pos)
 
 struct MoveLeft <: AbstractGridWorldAction end
 const MOVE_LEFT = MoveLeft()
-(::MoveLeft)(p::CartesianIndex{2}) = LEFT(p)
 move(::MoveLeft, pos::CartesianIndex{2}) = move(LEFT, pos)
 
 struct MoveRight <: AbstractGridWorldAction end
 const MOVE_RIGHT = MoveRight()
-(::MoveRight)(p::CartesianIndex{2}) = RIGHT(p)
 move(::MoveRight, pos::CartesianIndex{2}) = move(RIGHT, pos)
 
 struct PickUp <: AbstractGridWorldAction end

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -8,19 +8,17 @@ const MOVE_FORWARD = MoveForward()
 
 struct TurnLeft <: AbstractGridWorldAction end
 const TURN_LEFT = TurnLeft()
-
-(x::TurnLeft)(::Up) = LEFT
-(x::TurnLeft)(::Down) = RIGHT
-(x::TurnLeft)(::Left) = DOWN
-(x::TurnLeft)(::Right) = UP
+turn(::TurnLeft, ::Up) = LEFT
+turn(::TurnLeft, ::Down) = RIGHT
+turn(::TurnLeft, ::Left) = DOWN
+turn(::TurnLeft, ::Right) = UP
 
 struct TurnRight <: AbstractGridWorldAction end
 const TURN_RIGHT = TurnRight()
-
-(x::TurnRight)(::Up) = RIGHT
-(x::TurnRight)(::Down) = LEFT
-(x::TurnRight)(::Left) = UP
-(x::TurnRight)(::Right) = DOWN
+turn(::TurnRight, ::Up) = RIGHT
+turn(::TurnRight, ::Down) = LEFT
+turn(::TurnRight, ::Left) = UP
+turn(::TurnRight, ::Right) = DOWN
 
 struct MoveUp <: AbstractGridWorldAction end
 const MOVE_UP = MoveUp()

--- a/src/directions.jl
+++ b/src/directions.jl
@@ -6,17 +6,21 @@ abstract type AbstractDirection end
 struct Up <: AbstractDirection end
 const UP = Up()
 (x::Up)(p::CartesianIndex{2}) = p + CartesianIndex(-1, 0)
+move(::Up, pos::CartesianIndex{2}) = pos + CartesianIndex(-1, 0)
 
 struct Down <: AbstractDirection end
 const DOWN = Down()
 (x::Down)(p::CartesianIndex{2}) = p + CartesianIndex(1, 0)
+move(::Down, pos::CartesianIndex{2}) = pos + CartesianIndex(1, 0)
 
 struct Left <: AbstractDirection end
 const LEFT = Left()
 (x::Left)(p::CartesianIndex{2}) = p + CartesianIndex(0, -1)
+move(::Left, pos::CartesianIndex{2}) = pos + CartesianIndex(0, -1)
 
 struct Right <: AbstractDirection end
 const RIGHT = Right()
 (x::Right)(p::CartesianIndex{2}) = p + CartesianIndex(0, 1)
+move(::Right, pos::CartesianIndex{2}) = pos + CartesianIndex(0, 1)
 
 const DIRECTIONS = (UP, DOWN, LEFT, RIGHT)

--- a/src/directions.jl
+++ b/src/directions.jl
@@ -5,22 +5,18 @@ abstract type AbstractDirection end
 
 struct Up <: AbstractDirection end
 const UP = Up()
-(x::Up)(p::CartesianIndex{2}) = p + CartesianIndex(-1, 0)
 move(::Up, pos::CartesianIndex{2}) = pos + CartesianIndex(-1, 0)
 
 struct Down <: AbstractDirection end
 const DOWN = Down()
-(x::Down)(p::CartesianIndex{2}) = p + CartesianIndex(1, 0)
 move(::Down, pos::CartesianIndex{2}) = pos + CartesianIndex(1, 0)
 
 struct Left <: AbstractDirection end
 const LEFT = Left()
-(x::Left)(p::CartesianIndex{2}) = p + CartesianIndex(0, -1)
 move(::Left, pos::CartesianIndex{2}) = pos + CartesianIndex(0, -1)
 
 struct Right <: AbstractDirection end
 const RIGHT = Right()
-(x::Right)(p::CartesianIndex{2}) = p + CartesianIndex(0, 1)
 move(::Right, pos::CartesianIndex{2}) = pos + CartesianIndex(0, 1)
 
 const DIRECTIONS = (UP, DOWN, LEFT, RIGHT)

--- a/src/directions.jl
+++ b/src/directions.jl
@@ -1,6 +1,3 @@
-export AbstractDirection, Up, Down, Left, Right
-export UP, DOWN, LEFT, RIGHT, DIRECTIONS
-
 abstract type AbstractDirection end
 
 struct Up <: AbstractDirection end

--- a/src/directions.jl
+++ b/src/directions.jl
@@ -1,4 +1,4 @@
-export AbstractDirection, Up, Down, Left, Right, Direction
+export AbstractDirection, Up, Down, Left, Right
 export UP, DOWN, LEFT, RIGHT, DIRECTIONS
 
 abstract type AbstractDirection end
@@ -19,5 +19,4 @@ struct Right <: AbstractDirection end
 const RIGHT = Right()
 (x::Right)(p::CartesianIndex{2}) = p + CartesianIndex(0, 1)
 
-const Direction = Union{Up, Down, Left, Right}
 const DIRECTIONS = (UP, DOWN, LEFT, RIGHT)

--- a/src/directions.jl
+++ b/src/directions.jl
@@ -1,19 +1,21 @@
-export Up, Down, Left, Right, Direction
+export AbstractDirection, Up, Down, Left, Right, Direction
 export UP, DOWN, LEFT, RIGHT, DIRECTIONS
 
-struct Up end
+abstract type AbstractDirection end
+
+struct Up <: AbstractDirection end
 const UP = Up()
 (x::Up)(p::CartesianIndex{2}) = p + CartesianIndex(-1, 0)
 
-struct Down end
+struct Down <: AbstractDirection end
 const DOWN = Down()
 (x::Down)(p::CartesianIndex{2}) = p + CartesianIndex(1, 0)
 
-struct Left end
+struct Left <: AbstractDirection end
 const LEFT = Left()
 (x::Left)(p::CartesianIndex{2}) = p + CartesianIndex(0, -1)
 
-struct Right end
+struct Right <: AbstractDirection end
 const RIGHT = Right()
 (x::Right)(p::CartesianIndex{2}) = p + CartesianIndex(0, 1)
 

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -25,7 +25,7 @@ function CollectGems(; height = 8, width = 8, num_gem_init = floor(Int, sqrt(hei
 
     env = CollectGems(world, agent, reward, rng, num_gem_init, num_gem_current, gem_reward, gem_pos)
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -33,17 +33,19 @@ end
 RLBase.is_terminated(env::CollectGems) = env.num_gem_current <= 0
 
 function (env::CollectGems)(::MoveForward)
+    world = get_world(env)
+
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
-    if !env[WALL, dest]
+    if !world[WALL, dest]
         set_agent_pos!(env, dest)
     end
 
     set_reward!(env, 0.0)
     agent_pos = get_agent_pos(env)
-    if env[GEM, agent_pos]
-        env[GEM, agent_pos] = false
-        env[EMPTY, agent_pos] = true
+    if world[GEM, agent_pos]
+        world[GEM, agent_pos] = false
+        world[EMPTY, agent_pos] = true
         env.num_gem_current = env.num_gem_current - 1
         set_reward!(env, env.gem_reward)
     end
@@ -52,23 +54,24 @@ function (env::CollectGems)(::MoveForward)
 end
 
 function RLBase.reset!(env::CollectGems)
+    world = get_world(env)
     rng = get_rng(env)
 
     for pos in env.gem_pos
-        env[GEM, pos] = false
-        env[EMPTY, pos] = true
+        world[GEM, pos] = false
+        world[EMPTY, pos] = true
     end
 
     env.gem_pos = CartesianIndex{2}[]
     for i in 1:env.num_gem_init
-        pos = rand(rng, pos -> env[EMPTY, pos], env)
-        env[GEM, pos] = true
-        env[EMPTY, pos] = false
+        pos = rand(rng, pos -> world[EMPTY, pos], env)
+        world[GEM, pos] = true
+        world[EMPTY, pos] = false
         push!(env.gem_pos, pos)
     end
     env.num_gem_current = env.num_gem_init
 
-    agent_start_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    agent_start_pos = rand(rng, pos -> world[EMPTY, pos], env)
     agent_start_dir = rand(rng, DIRECTIONS)
 
     set_agent_pos!(env, agent_start_pos)

--- a/src/envs/collectgems.jl
+++ b/src/envs/collectgems.jl
@@ -36,7 +36,7 @@ function (env::CollectGems)(::MoveForward)
     world = get_world(env)
 
     dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
+    dest = move(dir, get_agent_pos(env))
     if !world[WALL, dest]
         set_agent_pos!(env, dest)
     end

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -28,7 +28,7 @@ function DoorKey(; height = 7, width = 7, rng = Random.GLOBAL_RNG)
 
     env = DoorKey(world, agent, reward, rng, terminal_reward, goal_pos, door_pos, key_pos)
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end
@@ -55,7 +55,7 @@ function (env::DoorKey)(::MoveForward)
     end
 
     set_reward!(env, 0.0)
-    if is_terminated(env)
+    if RLBase.is_terminated(env)
         set_reward!(env, env.terminal_reward)
     end
 

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -44,7 +44,7 @@ function (env::DoorKey)(::MoveForward)
     key = objects[end]
 
     dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
+    dest = move(dir, get_agent_pos(env))
 
     if world[door, dest]
         if get_inventory(env) === key

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -36,6 +36,7 @@ end
 RLBase.action_space(env::DoorKey) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, PICK_UP)
 
 function (env::DoorKey)(::MoveForward)
+    world = get_world(env)
     objects = get_objects(env)
     agent = get_agent(env)
 
@@ -45,11 +46,11 @@ function (env::DoorKey)(::MoveForward)
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
 
-    if env[door, dest]
+    if world[door, dest]
         if get_inventory(env) === key
             set_agent_pos!(env, dest)
         end
-    elseif !env[WALL, dest]
+    elseif !world[WALL, dest]
         set_agent_pos!(env, dest)
     end
 
@@ -62,14 +63,15 @@ function (env::DoorKey)(::MoveForward)
 end
 
 function (env::DoorKey)(::PickUp)
+    world = get_world(env)
     objects = get_objects(env)
 
     key = objects[end]
     agent_pos = get_agent_pos(env)
 
-    if env[key, agent_pos] && isnothing(get_inventory(env))
-        env[key, agent_pos] = false
-        env[EMPTY, agent_pos] = true
+    if world[key, agent_pos] && isnothing(get_inventory(env))
+        world[key, agent_pos] = false
+        world[EMPTY, agent_pos] = true
         set_inventory!(env, key)
     end
 
@@ -77,48 +79,48 @@ function (env::DoorKey)(::PickUp)
 end
 
 function RLBase.reset!(env::DoorKey)
+    world = get_world(env)
     height = get_height(env)
     width = get_width(env)
     rng = get_rng(env)
-
     objects = get_objects(env)
     door = objects[end - 1]
     key = objects[end]
 
-    env[WALL, 2:height-1, env.door_pos[2]] .= false
-    env[door, env.door_pos] = false
-    env[EMPTY, 2:height-1, env.door_pos[2]] .= true
+    world[WALL, 2:height-1, env.door_pos[2]] .= false
+    world[door, env.door_pos] = false
+    world[EMPTY, 2:height-1, env.door_pos[2]] .= true
 
     if isnothing(get_inventory(env))
-        env[key, env.key_pos] = false
-        env[EMPTY, env.key_pos] = true
+        world[key, env.key_pos] = false
+        world[EMPTY, env.key_pos] = true
     end
 
     old_goal_pos = get_goal_pos(env)
-    env[GOAL, old_goal_pos] = false
-    env[EMPTY, old_goal_pos] = true
+    world[GOAL, old_goal_pos] = false
+    world[EMPTY, old_goal_pos] = true
 
     new_door_pos = rand(rng, CartesianIndices((2:height-1, 3:width-2)))
     env.door_pos = new_door_pos
-    env[door, new_door_pos] = true
-    env[WALL, 2:height-1, new_door_pos[2]] .= true
-    env[WALL, new_door_pos] = false
-    env[EMPTY, 2:height-1, new_door_pos[2]] .= false
+    world[door, new_door_pos] = true
+    world[WALL, 2:height-1, new_door_pos[2]] .= true
+    world[WALL, new_door_pos] = false
+    world[EMPTY, 2:height-1, new_door_pos[2]] .= false
 
     left_region = CartesianIndices((2:height-1, 2:new_door_pos[2]-1))
     right_region = CartesianIndices((2:height-1, new_door_pos[2]+1:width-1))
 
-    new_goal_pos = rand(rng, pos -> env[EMPTY, pos], right_region)
+    new_goal_pos = rand(rng, pos -> world[EMPTY, pos], right_region)
     set_goal_pos!(env, new_goal_pos)
-    env[GOAL, new_goal_pos] = true
-    env[EMPTY, new_goal_pos] = false
+    world[GOAL, new_goal_pos] = true
+    world[EMPTY, new_goal_pos] = false
 
-    new_key_pos = rand(rng, pos -> env[EMPTY, pos], left_region)
+    new_key_pos = rand(rng, pos -> world[EMPTY, pos], left_region)
     env.key_pos = new_key_pos
-    env[key, new_key_pos] = true
-    env[EMPTY, new_key_pos] = false
+    world[key, new_key_pos] = true
+    world[EMPTY, new_key_pos] = false
 
-    agent_start_pos = rand(rng, pos -> env[EMPTY, pos], left_region)
+    agent_start_pos = rand(rng, pos -> world[EMPTY, pos], left_region)
     agent_start_dir = rand(rng, DIRECTIONS)
 
     set_agent_pos!(env, agent_start_pos)

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -33,7 +33,7 @@ function DoorKey(; height = 7, width = 7, rng = Random.GLOBAL_RNG)
     return env
 end
 
-RLBase.action_space(env::DoorKey) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, PICK_UP)
+RLBase.action_space(env::DoorKey, ::RLBase.DefaultPlayer) = (MOVE_FORWARD, TURN_LEFT, TURN_RIGHT, PICK_UP)
 
 function (env::DoorKey)(::MoveForward)
     world = get_world(env)

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -35,19 +35,20 @@ function DynamicObstacles(; height = 8, width = 8, num_obstacles = floor(Int, sq
     return env
 end
 
-iscollision(env::DynamicObstacles) = env[OBSTACLE, get_agent_pos(env)]
+iscollision(env::DynamicObstacles) = get_world(env)[OBSTACLE, get_agent_pos(env)]
 
 function (env::DynamicObstacles)(::MoveForward)
+    world = get_world(env)
     update_obstacles!(env)
 
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
-    if !env[WALL, dest]
+    if !world[WALL, dest]
         set_agent_pos!(env, dest)
     end
 
     set_reward!(env, 0.0)
-    if env[GOAL, get_agent_pos(env)]
+    if world[GOAL, get_agent_pos(env)]
         set_reward!(env, env.terminal_reward)
     elseif iscollision(env)
         set_reward!(env, env.terminal_penalty)
@@ -57,12 +58,13 @@ function (env::DynamicObstacles)(::MoveForward)
 end
 
 function (env::DynamicObstacles)(action::Union{TurnRight, TurnLeft})
+    world = get_world(env)
     update_obstacles!(env)
 
     set_agent_dir!(env, action(get_agent_dir(env)))
 
     set_reward!(env, 0.0)
-    if env[GOAL, get_agent_pos(env)]
+    if world[GOAL, get_agent_pos(env)]
         set_reward!(env, env.terminal_reward)
     elseif iscollision(env)
         set_reward!(env, env.terminal_penalty)
@@ -72,55 +74,58 @@ function (env::DynamicObstacles)(action::Union{TurnRight, TurnLeft})
 end
 
 function valid_obstacle_dest(env::DynamicObstacles, pos::CartesianIndex{2})
+    world = get_world(env)
     candidate_pos = [CartesianIndex(pos[1] + i, pos[2] + j) for i in [-1, 0, 1] for j in [-1, 0, 1]]
-    filter(p -> (env[EMPTY, p] || p == pos), candidate_pos)
+    filter(p -> (world[EMPTY, p] || p == pos), candidate_pos)
 end
 
 function update_obstacles!(env::DynamicObstacles)
+    world = get_world(env)
     for (i, pos) in enumerate(env.obstacle_pos)
-        env[OBSTACLE, pos] = false
-        env[EMPTY, pos] = true
+        world[OBSTACLE, pos] = false
+        world[EMPTY, pos] = true
 
         new_pos = rand(get_rng(env), valid_obstacle_dest(env, pos))
         env.obstacle_pos[i] = new_pos
 
-        env[OBSTACLE, new_pos] = true
-        env[EMPTY, new_pos] = false
+        world[OBSTACLE, new_pos] = true
+        world[EMPTY, new_pos] = false
     end
     
     return env
 end
 
-RLBase.is_terminated(env::DynamicObstacles) = iscollision(env) || env[GOAL, get_agent_pos(env)]
+RLBase.is_terminated(env::DynamicObstacles) = iscollision(env) || get_world(env)[GOAL, get_agent_pos(env)]
 
 function RLBase.reset!(env::DynamicObstacles)
+    world = get_world(env)
     rng = get_rng(env)
 
     for pos in env.obstacle_pos
-        env[OBSTACLE, pos] = false
-        env[EMPTY, pos] = true
+        world[OBSTACLE, pos] = false
+        world[EMPTY, pos] = true
     end
 
     old_goal_pos = get_goal_pos(env)
-    env[GOAL, old_goal_pos] = false
-    env[EMPTY, old_goal_pos] = true
+    world[GOAL, old_goal_pos] = false
+    world[EMPTY, old_goal_pos] = true
 
-    new_goal_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    new_goal_pos = rand(rng, pos -> world[EMPTY, pos], env)
 
     set_goal_pos!(env, new_goal_pos)
-    env[GOAL, new_goal_pos] = true
-    env[EMPTY, new_goal_pos] = false
+    world[GOAL, new_goal_pos] = true
+    world[EMPTY, new_goal_pos] = false
 
     env.obstacle_pos = CartesianIndex{2}[]
 
     for i in 1:env.num_obstacles
-        pos = rand(rng, pos -> env[EMPTY, pos], env)
-        env[OBSTACLE, pos] = true
-        env[EMPTY, pos] = false
+        pos = rand(rng, pos -> world[EMPTY, pos], env)
+        world[OBSTACLE, pos] = true
+        world[EMPTY, pos] = false
         push!(env.obstacle_pos, pos)
     end
 
-    agent_start_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    agent_start_pos = rand(rng, pos -> world[EMPTY, pos], env)
     agent_start_dir = rand(rng, DIRECTIONS)
 
     set_agent_pos!(env, agent_start_pos)

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -42,7 +42,7 @@ function (env::DynamicObstacles)(::MoveForward)
     update_obstacles!(env)
 
     dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
+    dest = move(dir, get_agent_pos(env))
     if !world[WALL, dest]
         set_agent_pos!(env, dest)
     end

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -30,7 +30,7 @@ function DynamicObstacles(; height = 8, width = 8, num_obstacles = floor(Int, sq
 
     env = DynamicObstacles(world, agent, reward, rng, terminal_reward, goal_pos, num_obstacles, obstacle_pos, terminal_penalty)
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end

--- a/src/envs/dynamicobstacles.jl
+++ b/src/envs/dynamicobstacles.jl
@@ -61,7 +61,9 @@ function (env::DynamicObstacles)(action::Union{TurnRight, TurnLeft})
     world = get_world(env)
     update_obstacles!(env)
 
-    set_agent_dir!(env, action(get_agent_dir(env)))
+    dir = get_agent_dir(env)
+    new_dir = turn(action, dir)
+    set_agent_dir!(env, new_dir)
 
     set_reward!(env, 0.0)
     if world[GOAL, get_agent_pos(env)]

--- a/src/envs/emptyroom.jl
+++ b/src/envs/emptyroom.jl
@@ -31,19 +31,20 @@ function EmptyRoom(; height = 8, width = 8, rng = Random.GLOBAL_RNG)
 end
 
 function RLBase.reset!(env::EmptyRoom)
+    world = get_world(env)
     rng = get_rng(env)
 
     old_goal_pos = get_goal_pos(env)
-    env[GOAL, old_goal_pos] = false
-    env[EMPTY, old_goal_pos] = true
+    world[GOAL, old_goal_pos] = false
+    world[EMPTY, old_goal_pos] = true
 
-    new_goal_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    new_goal_pos = rand(rng, pos -> world[EMPTY, pos], env)
 
     set_goal_pos!(env, new_goal_pos)
-    env[GOAL, new_goal_pos] = true
-    env[EMPTY, new_goal_pos] = false
+    world[GOAL, new_goal_pos] = true
+    world[EMPTY, new_goal_pos] = false
 
-    agent_start_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    agent_start_pos = rand(rng, pos -> world[EMPTY, pos], env)
     agent_start_dir = rand(rng, DIRECTIONS)
 
     set_agent_pos!(env, agent_start_pos)

--- a/src/envs/emptyroom.jl
+++ b/src/envs/emptyroom.jl
@@ -25,7 +25,7 @@ function EmptyRoom(; height = 8, width = 8, rng = Random.GLOBAL_RNG)
 
     env = EmptyRoom(world, agent, reward, rng, terminal_reward, goal_pos)
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -91,10 +91,10 @@ function RLBase.reset!(env::GoToDoor)
     return env
 end
 
-function generate_door_pos(rng::AbstractRNG, height::Int, width::Int)
+function generate_door_pos(rng::Random.AbstractRNG, height::Int, width::Int)
     door_pos = [CartesianIndex(rand(rng, 2:height-1), 1),
                 CartesianIndex(rand(rng, 2:height-1), width),
                 CartesianIndex(1, rand(rng, 2:width-1)),
                 CartesianIndex(height, rand(rng, 2:width-1))]
-    return shuffle(rng, door_pos)
+    return Random.shuffle(rng, door_pos)
 end

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -41,15 +41,17 @@ RLBase.state(env::GoToDoor) = (get_agent_view(env), env.target)
 RLBase.is_terminated(env::GoToDoor) = get_agent_pos(env) in values(env.door_pos)
 
 function (env::GoToDoor)(::MoveForward)
+    world = get_world(env)
+
     dir = get_agent_dir(env)
     dest = dir(get_agent_pos(env))
-    if dest ∈ CartesianIndices((get_height(env), get_width(env))) && !env[WALL, dest]
+    if dest ∈ CartesianIndices((get_height(env), get_width(env))) && !world[WALL, dest]
         set_agent_pos!(env, dest)
     end
 
     set_reward!(env, 0.0)
     if is_terminated(env)
-        if env[env.target, get_agent_pos(env)]
+        if world[env.target, get_agent_pos(env)]
             set_reward!(env, env.terminal_reward)
         else
             set_reward!(env, env.terminal_penalty)
@@ -60,24 +62,25 @@ function (env::GoToDoor)(::MoveForward)
 end
 
 function RLBase.reset!(env::GoToDoor)
+    world = get_world(env)
     height = get_height(env)
     width = get_width(env)
     rng = get_rng(env)
 
     for (door, pos) in env.door_pos
-        env[door, pos] = false
-        env[WALL, pos] = true
+        world[door, pos] = false
+        world[WALL, pos] = true
     end
 
     env.door_pos = Dict(zip(keys(env.door_pos), generate_door_pos(rng, height, width)))
     for (door, pos) in env.door_pos
-        env[door, pos] = true
-        env[WALL, pos] = false
+        world[door, pos] = true
+        world[WALL, pos] = false
     end
 
     env.target = rand(rng, keys(env.door_pos))
 
-    agent_start_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    agent_start_pos = rand(rng, pos -> world[EMPTY, pos], env)
     agent_start_dir = rand(rng, DIRECTIONS)
 
     set_agent_pos!(env, agent_start_pos)

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -44,7 +44,7 @@ function (env::GoToDoor)(::MoveForward)
     world = get_world(env)
 
     dir = get_agent_dir(env)
-    dest = dir(get_agent_pos(env))
+    dest = move(dir, get_agent_pos(env))
     if dest ∈ CartesianIndices((get_height(env), get_width(env))) && !world[WALL, dest]
         set_agent_pos!(env, dest)
     end

--- a/src/envs/gotodoor.jl
+++ b/src/envs/gotodoor.jl
@@ -31,7 +31,7 @@ function GoToDoor(; height = 8, width = 8, rng = Random.GLOBAL_RNG)
 
     env = GoToDoor(world, agent, reward, rng, door_pos, target, terminal_reward, terminal_penalty)
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end
@@ -50,7 +50,7 @@ function (env::GoToDoor)(::MoveForward)
     end
 
     set_reward!(env, 0.0)
-    if is_terminated(env)
+    if RLBase.is_terminated(env)
         if world[env.target, get_agent_pos(env)]
             set_reward!(env, env.terminal_reward)
         else

--- a/src/envs/gridrooms.jl
+++ b/src/envs/gridrooms.jl
@@ -70,16 +70,16 @@ function RLBase.reset!(env::GridRooms)
     rng = get_rng(env)
 
     old_goal_pos = get_goal_pos(env)
-    env[GOAL, old_goal_pos] = false
-    env[EMPTY, old_goal_pos] = true
+    world[GOAL, old_goal_pos] = false
+    world[EMPTY, old_goal_pos] = true
 
-    new_goal_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    new_goal_pos = rand(rng, pos -> world[EMPTY, pos], env)
 
     set_goal_pos!(env, new_goal_pos)
-    env[GOAL, new_goal_pos] = true
-    env[EMPTY, new_goal_pos] = false
+    world[GOAL, new_goal_pos] = true
+    world[EMPTY, new_goal_pos] = false
 
-    agent_start_pos = rand(rng, pos -> env[EMPTY, pos], env)
+    agent_start_pos = rand(rng, pos -> world[EMPTY, pos], env)
     agent_start_dir = rand(rng, DIRECTIONS)
 
     set_agent_pos!(env, agent_start_pos)

--- a/src/envs/gridrooms.jl
+++ b/src/envs/gridrooms.jl
@@ -48,7 +48,7 @@ function GridRooms(; grid_size = (2, 2), room_size = (5, 5), rng = Random.GLOBAL
 
     env = GridRooms(world, agent, reward, rng, terminal_reward, goal_pos)
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -54,8 +54,8 @@ function RLBase.reset!(env::AbstractGridWorld)
             push!(env.rooms, room)
 
             door_pos = rand(rng, intersect(env.rooms[end - 1].region, room.region)[2:end-1])
-            env[WALL, door_pos] = false
-            env[EMPTY, door_pos] = true
+            world[WALL, door_pos] = false
+            world[EMPTY, door_pos] = true
         end
 
         tries += 1
@@ -65,14 +65,15 @@ function RLBase.reset!(env::AbstractGridWorld)
     centered_world = get_centered_world(world)
     shift_rooms!(env)
     set_world!(env, centered_world)
+    world = get_world(env)
 
     # add the GOAL randomly in the last room
     goal_pos = rand(rng, get_interior(env.rooms[end]))
     while goal_pos == get_agent_pos(env)
         goal_pos = rand(rng, get_interior(env.rooms[end]))
     end
-    env[GOAL, goal_pos] = true
-    env[EMPTY, goal_pos] = false
+    world[GOAL, goal_pos] = true
+    world[EMPTY, goal_pos] = false
 
     # add the agent randomly in the first room
     agent_start_pos = get_interior(env.rooms[1])

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -110,7 +110,7 @@ function generate_candidate_rooms(env::SequentialRooms)
     return rooms
 end
 
-function generate_candidate_rooms(env::SequentialRooms, height::Int, width::Int, dir::Direction)
+function generate_candidate_rooms(env::SequentialRooms, height::Int, width::Int, dir::AbstractDirection)
     origins = generate_candidate_origins(env.rooms[end], height, width, dir)
     rooms = map(x -> Room(x, height, width), origins)
     valid_rooms = filter(x -> is_valid_room(env, x), rooms)

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -21,7 +21,7 @@ function SequentialRooms(; num_rooms = 3, room_length_range = 4:6, rng = Random.
 
     env = SequentialRooms(world, agent, reward, rng, terminal_reward, num_rooms, room_length_range, Room[])
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end

--- a/src/envs/sokoban/sokoban.jl
+++ b/src/envs/sokoban/sokoban.jl
@@ -70,12 +70,12 @@ RLBase.state(env::Sokoban, ::RLBase.InternalState, ::DefaultPlayer) = get_full_v
 
 RLBase.action_space(env::Sokoban, ::DefaultPlayer) = (MOVE_UP, MOVE_DOWN, MOVE_LEFT, MOVE_RIGHT)
 
-RLBase.is_terminated(env::Sokoban) = all(pos -> env[TARGET, pos], env.box_pos)
+RLBase.is_terminated(env::Sokoban) = all(pos -> get_world(env)[TARGET, pos], env.box_pos)
 
 function (env::AbstractGridWorld)(action::Union{MoveUp, MoveDown, MoveLeft, MoveRight})
     world = get_world(env)
 
-    r1 = sum(pos -> env[TARGET, pos], env.box_pos)
+    r1 = sum(pos -> world[TARGET, pos], env.box_pos)
     agent_pos = get_agent_pos(env)
     dest = action(agent_pos)
     if !world[WALL, dest]
@@ -109,18 +109,19 @@ function (env::AbstractGridWorld)(action::Union{MoveUp, MoveDown, MoveLeft, Move
         end
     end
 
-    r2 = sum(pos -> env[TARGET, pos], env.box_pos)
+    r2 = sum(pos -> world[TARGET, pos], env.box_pos)
     set_reward!(env, r2 - r1)
 
     return env
 end
 
 function set_level!(env::Sokoban, level::Vector{String})
+    world = get_world(env)
     for i in 1:length(level)
         for j in 1:length(level[1])
             pos = CartesianIndex(i, j)
             object = CHAR_TO_OBJECT[level[i][j]]
-            env[object, pos] = true
+            world[object, pos] = true
 
             if object === DIRECTION_LESS_AGENT
                 set_agent_pos!(env, pos)

--- a/src/envs/sokoban/sokoban.jl
+++ b/src/envs/sokoban/sokoban.jl
@@ -77,9 +77,9 @@ function (env::AbstractGridWorld)(action::Union{MoveUp, MoveDown, MoveLeft, Move
 
     r1 = sum(pos -> world[TARGET, pos], env.box_pos)
     agent_pos = get_agent_pos(env)
-    dest = action(agent_pos)
+    dest = move(action, agent_pos)
     if !world[WALL, dest]
-        beyond_dest = action(dest)
+        beyond_dest = move(action, dest)
         if !world[BOX, dest]
             world[DIRECTION_LESS_AGENT, agent_pos] = false
             world[DIRECTION_LESS_AGENT, dest] = true

--- a/src/envs/sokoban/sokoban.jl
+++ b/src/envs/sokoban/sokoban.jl
@@ -59,16 +59,16 @@ function Sokoban(; file = joinpath(dirname(pathof(@__MODULE__)), "envs/sokoban/0
 
     env = Sokoban(world, agent, reward, rng, dataset, box_pos, target_pos)
 
-    reset!(env)
+    RLBase.reset!(env)
 
     return env
 end
 
 get_full_view(env::Sokoban) = get_grid(env)
 RLBase.StateStyle(env::Sokoban) = RLBase.InternalState{Any}()
-RLBase.state(env::Sokoban, ::RLBase.InternalState, ::DefaultPlayer) = get_full_view(env)
+RLBase.state(env::Sokoban, ::RLBase.InternalState, ::RLBase.DefaultPlayer) = get_full_view(env)
 
-RLBase.action_space(env::Sokoban, ::DefaultPlayer) = (MOVE_UP, MOVE_DOWN, MOVE_LEFT, MOVE_RIGHT)
+RLBase.action_space(env::Sokoban, ::RLBase.DefaultPlayer) = (MOVE_UP, MOVE_DOWN, MOVE_LEFT, MOVE_RIGHT)
 
 RLBase.is_terminated(env::Sokoban) = all(pos -> get_world(env)[TARGET, pos], env.box_pos)
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,5 +1,4 @@
 export GridWorldBase
-export get_grid, get_objects, get_num_objects, get_height, get_width, get_agent_view!
 
 #####
 # GridWorldBase

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -60,7 +60,7 @@ ind_map((i,j), (m, n), ::Down) = (i,j)
 ind_map((i,j), (m, n), ::Left) = (m-j+1, i)
 ind_map((i,j), (m, n), ::Right) = (j, n-i+1)
 
-function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{Bool,3}, agent_pos::CartesianIndex{2}, dir::Direction)
+function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{Bool,3}, agent_pos::CartesianIndex{2}, dir::AbstractDirection)
     view_size = (get_height(agent_view), get_width(agent_view))
     grid_size = (get_height(grid), get_width(grid))
     inds = get_agent_view_inds(agent_pos.I, view_size, dir)

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -78,7 +78,7 @@ end
 # utils
 #####
 
-function Random.rand(rng::AbstractRNG, f::Function, inds::Union{Vector{CartesianIndex{2}}, CartesianIndices{2}}; max_try::Int = 1000)
+function Random.rand(rng::Random.AbstractRNG, f::Function, inds::Union{Vector{CartesianIndex{2}}, CartesianIndices{2}}; max_try::Int = 1000)
     for _ in 1:max_try
         pos = rand(rng, inds)
         if f(pos)
@@ -89,7 +89,7 @@ function Random.rand(rng::AbstractRNG, f::Function, inds::Union{Vector{Cartesian
     return nothing
 end
 
-function Random.rand(rng::AbstractRNG, f::Function, world::GridWorldBase; max_try = 1000)
+function Random.rand(rng::Random.AbstractRNG, f::Function, world::GridWorldBase; max_try = 1000)
     inds = CartesianIndices((get_height(world), get_width(world)))
     rand(rng, f, inds, max_try = max_try)
 end

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -1,9 +1,3 @@
-export GridWorldBase
-
-#####
-# GridWorldBase
-#####
-
 """
     GridWorldBase{O} <: AbstractArray{Bool, 3}
 

--- a/src/makie_rendering.jl
+++ b/src/makie_rendering.jl
@@ -1,16 +1,16 @@
 export play
 
-using .Makie
+import .Makie
 
 get_transform(x::Int) = pos -> CartesianIndex(pos[2], x - pos[1] + 1)
 get_center(pos, tile_size, transform) = (transform(pos).I .- (0.5,0.5)) .* reverse(tile_size)
-get_box(pos, tile_size, transform) = FRect2D((transform(pos).I .- (1,1)) .* reverse(tile_size), reverse(tile_size))
+get_box(pos, tile_size, transform) = Makie.FRect2D((transform(pos).I .- (1,1)) .* reverse(tile_size), reverse(tile_size))
 
 get_markersize(object::AbstractObject, tile_size) = reverse(tile_size)
 get_markersize(object::Empty, tile_size) = reverse(tile_size) ./ 5
 
-function init_screen(env_node::Observable{<:AbstractGridWorld}; resolution = (720, 720))
-    scene = Scene(resolution = resolution, raw = true, camera = campixel!)
+function init_screen(env_node::Makie.Observable{<:AbstractGridWorld}; resolution = (720, 720))
+    scene = Makie.Scene(resolution = resolution, raw = true, camera = Makie.campixel!)
 
     height = get_height(env_node[])
     width = get_width(env_node[])
@@ -19,32 +19,32 @@ function init_screen(env_node::Observable{<:AbstractGridWorld}; resolution = (72
     transform = get_transform(height)
 
     area = scene.px_area
-    tile_size = @lift((widths($area)[2] / height, widths($area)[1] / width))
+    tile_size = Makie.@lift((Makie.widths($area)[2] / height, Makie.widths($area)[1] / width))
 
     # 1. paint background
-    poly!(scene, area)
-    scatter!(scene, @lift(map(x -> get_center(x, $tile_size, transform), filter(pos -> !any(get_world($env_node)[:, pos]), $tile_inds))), color = :white, marker = '~', markersize = @lift((reverse($tile_size) ./ 2)))
+    Makie.poly!(scene, area)
+    Makie.scatter!(scene, Makie.@lift(map(x -> get_center(x, $tile_size, transform), filter(pos -> !any(get_world($env_node)[:, pos]), $tile_inds))), color = :white, marker = '~', markersize = Makie.@lift((reverse($tile_size) ./ 2)))
 
     # 2. paint each kind of object
     for object in get_objects(env_node[])
-        scatter!(scene, @lift(broadcast(x -> get_center(x, $tile_size, transform), findall(get_world($env_node)[object, :, :]))), color = get_color(object), marker = get_char(object), markersize = @lift(get_markersize(object, $tile_size)))
+        Makie.scatter!(scene, Makie.@lift(broadcast(x -> get_center(x, $tile_size, transform), findall(get_world($env_node)[object, :, :]))), color = get_color(object), marker = get_char(object), markersize = Makie.@lift(get_markersize(object, $tile_size)))
     end
 
     # 3. paint agent's view
-    view_boxes = @lift(map(pos -> get_box(pos, $tile_size, transform), filter(pos -> pos in tile_inds, get_agent_view_inds($env_node))))
-    poly!(scene, view_boxes, color = "rgba(255,255,255,0.3)")
+    view_boxes = Makie.@lift(map(pos -> get_box(pos, $tile_size, transform), filter(pos -> pos in tile_inds, get_agent_view_inds($env_node))))
+    Makie.poly!(scene, view_boxes, color = "rgba(255,255,255,0.3)")
 
     # 4. paint agent
-    agent = @lift(get_agent($env_node))
-    agent_center = @lift(get_center(get_agent_pos($env_node), $tile_size, transform))
-    scatter!(scene, agent_center, color = @lift(get_color($agent)), marker = @lift(get_char($agent)), markersize = @lift(get_markersize($agent, $tile_size)))
+    agent = Makie.@lift(get_agent($env_node))
+    agent_center = Makie.@lift(get_center(get_agent_pos($env_node), $tile_size, transform))
+    Makie.scatter!(scene, agent_center, color = Makie.@lift(get_color($agent)), marker = Makie.@lift(get_char($agent)), markersize = Makie.@lift(get_markersize($agent, $tile_size)))
 
-    display(scene)
+    Makie.display(scene)
     scene
 end
 
-function init_screen(env_node::Observable{<:Sokoban}; resolution = (720, 720))
-    scene = Scene(resolution = resolution, raw = true, camera = campixel!)
+function init_screen(env_node::Makie.Observable{<:Sokoban}; resolution = (720, 720))
+    scene = Makie.Scene(resolution = resolution, raw = true, camera = Makie.campixel!)
 
     height = get_height(env_node[])
     width = get_width(env_node[])
@@ -53,18 +53,18 @@ function init_screen(env_node::Observable{<:Sokoban}; resolution = (720, 720))
     transform = get_transform(height)
 
     area = scene.px_area
-    tile_size = @lift((widths($area)[2] / height, widths($area)[1] / width))
+    tile_size = Makie.@lift((Makie.widths($area)[2] / height, Makie.widths($area)[1] / width))
 
     # 1. paint background
-    poly!(scene, area)
-    scatter!(scene, @lift(map(x -> get_center(x, $tile_size, transform), filter(pos -> !any(get_world($env_node)[:, pos]), $tile_inds))), color = :white, marker = '~', markersize = @lift((reverse($tile_size) ./ 2)))
+    Makie.poly!(scene, area)
+    Makie.scatter!(scene, Makie.@lift(map(x -> get_center(x, $tile_size, transform), filter(pos -> !any(get_world($env_node)[:, pos]), $tile_inds))), color = :white, marker = '~', markersize = Makie.@lift((reverse($tile_size) ./ 2)))
 
     # 2. paint each kind of object
     for object in get_objects(env_node[])
-        scatter!(scene, @lift(broadcast(x -> get_center(x, $tile_size, transform), findall(get_world($env_node)[object, :, :]))), color = get_color(object), marker = get_char(object), markersize = @lift(get_markersize(object, $tile_size)))
+        Makie.scatter!(scene, Makie.@lift(broadcast(x -> get_center(x, $tile_size, transform), findall(get_world($env_node)[object, :, :]))), color = get_color(object), marker = get_char(object), markersize = Makie.@lift(get_markersize(object, $tile_size)))
     end
 
-    display(scene)
+    Makie.display(scene)
     scene
 end
 
@@ -82,47 +82,47 @@ function play(env::AbstractGridWorld;file_name=nothing,frame_rate=24)
     r: reset!
     q: Quit
     """)
-    env_node = Node(env)
+    env_node = Makie.Node(env)
     scene = init_screen(env_node)
     is_quit = Ref(false)
 
     if !isnothing(file_name)
-        vs = VideoStream(scene)
-        recordframe!(vs)
+        vs = Makie.VideoStream(scene)
+        Makie.recordframe!(vs)
     end
 
-    on(scene.events.keyboardbuttons) do b
-        if ispressed(b, Keyboard.left)
+    Makie.on(scene.events.keyboardbuttons) do b
+        if Makie.ispressed(b, Makie.Keyboard.left)
             env(TURN_LEFT)
             env_node[] = env
-        elseif ispressed(b, Keyboard.right)
+        elseif Makie.ispressed(b, Makie.Keyboard.right)
             env(TURN_RIGHT)
             env_node[] = env
-        elseif ispressed(b, Keyboard.up)
+        elseif Makie.ispressed(b, Makie.Keyboard.up)
             env(MOVE_FORWARD)
             env_node[] = env
-        elseif ispressed(b, Keyboard.w)
+        elseif Makie.ispressed(b, Makie.Keyboard.w)
             env(MOVE_UP)
             env_node[] = env
-        elseif ispressed(b, Keyboard.s)
+        elseif Makie.ispressed(b, Makie.Keyboard.s)
             env(MOVE_DOWN)
             env_node[] = env
-        elseif ispressed(b, Keyboard.a)
+        elseif Makie.ispressed(b, Makie.Keyboard.a)
             env(MOVE_LEFT)
             env_node[] = env
-        elseif ispressed(b, Keyboard.d)
+        elseif Makie.ispressed(b, Makie.Keyboard.d)
             env(MOVE_RIGHT)
             env_node[] = env
-        elseif ispressed(b, Keyboard.p)
+        elseif Makie.ispressed(b, Makie.Keyboard.p)
             env(PICK_UP)
             env_node[] = env
-        elseif ispressed(b, Keyboard.r)
+        elseif Makie.ispressed(b, Makie.Keyboard.r)
             reset!(env)
             env_node[] = env
-        elseif ispressed(b, Keyboard.q)
+        elseif Makie.ispressed(b, Makie.Keyboard.q)
             is_quit[] = true
         end
-        isnothing(file_name) || recordframe!(vs)
+        isnothing(file_name) || Makie.recordframe!(vs)
     end
 
     try
@@ -131,6 +131,6 @@ function play(env::AbstractGridWorld;file_name=nothing,frame_rate=24)
         end
     catch
     end
-    isnothing(file_name) || save(file_name, vs;framerate=frame_rate)
+    isnothing(file_name) || Makie.save(file_name, vs;framerate=frame_rate)
     Makie.GLMakie.destroy!(Makie.GLMakie.global_gl_screen())
 end

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,6 +1,5 @@
 export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Box, Target, Agent
 export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE, BOX, TARGET
-export get_char, get_color, get_dir, set_dir!, get_pos, set_pos!, get_inventory_type, get_inventory, set_inventory!
 
 const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
 

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -68,7 +68,7 @@ get_color(::DirectionLessAgent) = :green
 
 mutable struct Agent{I, C} <: AbstractObject
     pos::CartesianIndex{2}
-    dir::Direction
+    dir::AbstractDirection
     inventory::I
 end
 
@@ -84,7 +84,7 @@ get_char(agent::Agent) = get_char(agent, get_dir(agent))
 
 get_color(agent::Agent{I, C}) where {I, C} = C
 get_dir(agent::Agent) = agent.dir
-set_dir!(agent::Agent, dir::Direction) = agent.dir = dir
+set_dir!(agent::Agent, dir::AbstractDirection) = agent.dir = dir
 get_pos(agent::Agent) = agent.pos
 set_pos!(agent::Agent, pos::CartesianIndex{2}) = agent.pos = pos
 

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,6 +1,3 @@
-export AbstractObject, Empty, Wall, Goal, Door, Key, Gem, Obstacle, Box, Target, Agent
-export COLORS, EMPTY, WALL, GOAL, GEM, OBSTACLE, BOX, TARGET
-
 const COLORS = (:red, :green, :blue, :magenta, :yellow, :white)
 
 #####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,11 +26,11 @@ get_terminal_rewards(env::Sokoban) = (1.0,)
                 @test reward(env) == 0.0
                 @test is_terminated(env) == false
                 if Env == GoToDoor
-                    @test state(env) == (get_agent_view(env), env.target)
+                    @test state(env) == (GW.get_agent_view(env), env.target)
                 elseif Env == Sokoban
-                    @test state(env) == get_full_view(env)
+                    @test state(env) == GW.get_full_view(env)
                 else
-                    @test state(env) == get_agent_view(env)
+                    @test state(env) == GW.get_agent_view(env)
                 end
 
                 total_reward = 0.0
@@ -39,9 +39,9 @@ get_terminal_rewards(env::Sokoban) = (1.0,)
                     env(action)
                     total_reward += reward(env)
 
-                    @test 1 ≤ get_agent_pos(env)[1] ≤ get_height(env)
-                    @test 1 ≤ get_agent_pos(env)[2] ≤ get_width(env)
-                    @test get_world(env)[WALL, get_agent_pos(env)] == false
+                    @test 1 ≤ GW.get_agent_pos(env)[1] ≤ GW.get_height(env)
+                    @test 1 ≤ GW.get_agent_pos(env)[2] ≤ GW.get_width(env)
+                    @test GW.get_world(env)[GW.WALL, GW.get_agent_pos(env)] == false
 
                     if is_terminated(env)
                         @test total_reward in get_terminal_rewards(env)


### PR DESCRIPTION
1. `import` instead of `using` packages
    1. Much better clarity on the sources of types and methods. As in, what comes from which package.
    2. `Makie 0.11.2` has `Left` and `Right` causing naming conflicts
    3. We can easily afford `import` since we don't have super heavy dependency on other packages
2. Add `AbstractDirection` and make it the supertype of `Up`, `Down`, `Left`, `Right`. Deprecate `Direction`
3. Add and use `move` and `turn` methods instead of functors for clarity.
4. Remove exports that are not necessary for using the environments.
5. merge PR #113 changes again since I forgot to rebase my branch for this PR 😅 