### PR TITLE
Refactor agent view related methods and other minor changes

### DIFF
--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -50,11 +50,7 @@ get_agent_start_dir(env::AbstractGridWorld, ::UndirectedNavigation) = CENTER
 # Agent's view
 #####
 
-function get_agent_view_size(env::AbstractGridWorld)
-    m = 2 * ceil(Int, get_height(env) / 4) + 1
-    n = 2 * ceil(Int, get_width(env) / 4) + 1
-    return (m, n)
-end
+get_agent_view_size(env::AbstractGridWorld) = (2 * (get_height(env) ÷ 4) + 1, 2 * (get_width(env) ÷ 4) + 1)
 
 get_agent_view_inds(env::AbstractGridWorld) = get_agent_view_inds(get_agent_pos(env).I, get_agent_view_size(env), get_agent_dir(env))
 

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -2,10 +2,6 @@ export AbstractGridWorld
 
 abstract type AbstractGridWorld <: RLBase.AbstractEnv end
 
-#####
-# Useful getters and setters
-#####
-
 get_world(env::AbstractGridWorld) = env.world
 set_world!(env::AbstractGridWorld, world::GridWorldBase) = env.world = world
 @forward AbstractGridWorld.world get_grid, get_objects, get_num_objects, get_height, get_width
@@ -28,7 +24,7 @@ set_goal_pos!(env::AbstractGridWorld, pos::CartesianIndex{2}) = env.goal_pos = p
 Random.rand(rng::Random.AbstractRNG, f::Function, env::AbstractGridWorld; max_try = 1000) = rand(rng, f, get_world(env), max_try = max_try)
 
 #####
-# Agent direction style trait
+# Navigation style trait
 #####
 
 abstract type AbstractNavigationStyle end
@@ -51,30 +47,12 @@ get_agent_start_dir(env::AbstractGridWorld, ::UndirectedNavigation) = CENTER
 #####
 
 get_agent_view_size(env::AbstractGridWorld) = (2 * (get_height(env) ÷ 4) + 1, 2 * (get_width(env) ÷ 4) + 1)
-get_window_size(env::AbstractGridWorld) = (2 * (get_height(env) ÷ 4) + 1, 2 * (get_width(env) ÷ 4) + 1)
 
 get_agent_view_inds(env::AbstractGridWorld) = get_grid_inds(get_agent_pos(env).I, get_agent_view_size(env), get_agent_dir(env))
 
 get_agent_view(env::AbstractGridWorld) = get_grid(get_world(env), get_agent_view_size(env), get_agent_pos(env), get_agent_dir(env))
 
 get_agent_view!(agent_view::AbstractArray{Bool, 3}, env::AbstractGridWorld) = get_grid!(agent_view, get_world(env), get_agent_pos(env), get_agent_dir(env))
-
-#####
-# Full view
-#####
-
-function get_agent_layer(grid::BitArray{3}, agent_pos::CartesianIndex{2})
-    dims = size(grid)[2:end]
-    agent_layer = falses(1, dims...)
-    agent_layer[1, agent_pos] = true
-    return agent_layer
-end
-
-function get_full_view(env::AbstractGridWorld)
-    grid = get_grid(env)
-    agent_layer = get_agent_layer(grid, get_agent_pos(env))
-    return cat(agent_layer, grid, dims = 1)
-end
 
 function get_grid_with_agent_layer(env::AbstractGridWorld)
     grid = get_grid(env)
@@ -89,7 +67,7 @@ end
 
 const get_state = RLBase.state
 RLBase.state(env::AbstractGridWorld, ss::RLBase.AbstractStateStyle, player::RLBase.DefaultPlayer) = RLBase.state(env, ss, player, get_navigation_style(env))
-RLBase.state(env::AbstractGridWorld, ::RLBase.Observation, ::RLBase.DefaultPlayer) = get_grid(get_world(env), get_window_size(env), get_agent_pos(env), get_agent_dir(env))
+RLBase.state(env::AbstractGridWorld, ::RLBase.Observation, ::RLBase.DefaultPlayer) = get_agent_view(env)
 RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::RLBase.DefaultPlayer, ::DirectedNavigation) = (get_grid_with_agent_layer(env), get_agent_dir(env))
 RLBase.state(env::AbstractGridWorld, ::RLBase.InternalState, ::RLBase.DefaultPlayer, ::UndirectedNavigation) = get_grid_with_agent_layer(env)
 

--- a/src/envs/doorkey.jl
+++ b/src/envs/doorkey.jl
@@ -11,7 +11,7 @@ mutable struct DoorKey{W<:GridWorldBase, R} <: AbstractGridWorld
     key_pos::CartesianIndex{2}
 end
 
-function DoorKey(; height = 7, width = 7, rng = Random.GLOBAL_RNG)
+function DoorKey(; height = 8, width = 8, rng = Random.GLOBAL_RNG)
     door = Door(:yellow)
     key = Key(:yellow)
     objects = (EMPTY, WALL, GOAL, door, key)

--- a/src/envs/gridrooms.jl
+++ b/src/envs/gridrooms.jl
@@ -80,7 +80,7 @@ function RLBase.reset!(env::GridRooms)
     world[EMPTY, new_goal_pos] = false
 
     agent_start_pos = rand(rng, pos -> world[EMPTY, pos], env)
-    agent_start_dir = rand(rng, DIRECTIONS)
+    agent_start_dir = get_agent_start_dir(env)
 
     set_agent_pos!(env, agent_start_pos)
     set_agent_dir!(env, agent_start_dir)

--- a/src/envs/sequentialrooms.jl
+++ b/src/envs/sequentialrooms.jl
@@ -77,7 +77,7 @@ function RLBase.reset!(env::AbstractGridWorld)
 
     # add the agent randomly in the first room
     agent_start_pos = get_interior(env.rooms[1])
-    agent_start_dir = rand(rng, DIRECTIONS)
+    agent_start_dir = get_agent_start_dir(env)
 
     set_agent_pos!(env, rand(rng, agent_start_pos))
     set_agent_dir!(env, agent_start_dir)

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -18,9 +18,9 @@ end
 get_grid(world::GridWorldBase) = world.grid
 get_objects(world::GridWorldBase) = world.objects
 
-get_num_objects(grid::T) where {T <: AbstractArray{Bool, 3}} = size(grid, 1)
-get_height(grid::T) where {T <: AbstractArray{Bool, 3}} = size(grid, 2)
-get_width(grid::T) where {T <: AbstractArray{Bool, 3}} = size(grid, 3)
+get_num_objects(grid::AbstractArray{Bool, 3}) = size(grid, 1)
+get_height(grid::AbstractArray{Bool, 3}) = size(grid, 2)
+get_width(grid::AbstractArray{Bool, 3}) = size(grid, 3)
 
 #####
 # Indexing of GridWorldBase objects

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -38,43 +38,8 @@ Base.getindex(world::GridWorldBase, object::AbstractObject, args...) = getindex(
 Base.setindex!(world::GridWorldBase, value::Bool, object::AbstractObject, args...) = setindex!(get_grid(world), value, Base.to_index(world, object), args...)
 
 #####
-# get_agent_view
+# methods for agent view
 #####
-
-get_agent_view_inds((i, j), (m, n), ::Center) = CartesianIndices((i-m÷2:i-m÷2+m-1, j-n÷2:j-n÷2+n-1))
-get_agent_view_inds((i, j), (m, n), ::Up) = CartesianIndices((i-m+1:i, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
-get_agent_view_inds((i, j), (m, n), ::Down) = CartesianIndices((i:i+m-1, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
-get_agent_view_inds((i, j), (m, n), ::Left) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j-m+1:j))
-get_agent_view_inds((i, j), (m, n), ::Right) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j:j+m-1))
-
-ind_map((i,j), (m, n), ::Center) = (i,j)
-ind_map((i,j), (m, n), ::Up) = (m-i+1, n-j+1)
-ind_map((i,j), (m, n), ::Down) = (i,j)
-ind_map((i,j), (m, n), ::Left) = (m-j+1, i)
-ind_map((i,j), (m, n), ::Right) = (j, n-i+1)
-
-function get_agent_view(grid::AbstractArray{Bool, 3}, agent_view_size, agent_pos::CartesianIndex{2}, dir::AbstractDirection)
-    agent_view = falses(get_num_objects(grid), agent_view_size...)
-    get_agent_view!(agent_view, grid, agent_pos, dir)
-    return agent_view
-end
-
-function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{Bool,3}, agent_pos::CartesianIndex{2}, dir::AbstractDirection)
-    agent_view_inds_size = (get_height(agent_view), get_width(agent_view))
-    agent_view_inds = get_agent_view_inds(agent_pos.I, agent_view_inds_size, dir)
-
-    valid_inds_size = (get_height(grid), get_width(grid))
-    valid_inds = CartesianIndices(valid_inds_size)
-
-    for ind in CartesianIndices(agent_view_inds_size)
-        pos = agent_view_inds[ind]
-        if pos ∈ valid_inds
-            agent_view[:, ind_map(ind.I, agent_view_inds_size, dir)...] .= grid[:, pos]
-        end
-    end
-
-    return agent_view
-end
 
 get_grid_inds((i, j), (m, n), ::Center) = CartesianIndices((i-m÷2:i-m÷2+m-1, j-n÷2:j-n÷2+n-1))
 get_grid_inds((i, j), (m, n), ::Up) = CartesianIndices((i-m+1:i, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
@@ -95,16 +60,15 @@ function get_grid(src_grid::AbstractArray{Bool, 3}, window_size, pos::CartesianI
 end
 
 function get_grid!(dest_grid::AbstractArray{Bool, 3}, src_grid::AbstractArray{Bool, 3}, pos::CartesianIndex{2}, dir::AbstractDirection)
-    window_inds_size = (get_height(dest_grid), get_width(dest_grid))
+    window_size = (get_height(dest_grid), get_width(dest_grid))
     window_inds = get_grid_inds(pos.I, window_size, dir)
 
-    valid_inds_size = (get_height(src_grid), get_width(src_grid))
-    valid_inds = CartesianIndices(valid_inds_size)
+    valid_inds = CartesianIndices((get_height(src_grid), get_width(src_grid)))
 
-    for ind in CartesianIndices(window_inds_size)
+    for ind in CartesianIndices(window_inds)
         pos = window_inds[ind]
         if pos ∈ valid_inds
-            dest_grid[:, map_ind(ind.I, window_inds_size, dir)...] .= src_grid[:, pos]
+            dest_grid[:, map_ind(ind.I, window_size, dir)...] .= src_grid[:, pos]
         end
     end
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -76,6 +76,41 @@ function get_agent_view!(agent_view::AbstractArray{Bool,3}, grid::AbstractArray{
     return agent_view
 end
 
+get_grid_inds((i, j), (m, n), ::Center) = CartesianIndices((i-m÷2:i-m÷2+m-1, j-n÷2:j-n÷2+n-1))
+get_grid_inds((i, j), (m, n), ::Up) = CartesianIndices((i-m+1:i, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
+get_grid_inds((i, j), (m, n), ::Down) = CartesianIndices((i:i+m-1, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
+get_grid_inds((i, j), (m, n), ::Left) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j-m+1:j))
+get_grid_inds((i, j), (m, n), ::Right) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j:j+m-1))
+
+map_ind((i,j), (m, n), ::Center) = (i,j)
+map_ind((i,j), (m, n), ::Up) = (m-i+1, n-j+1)
+map_ind((i,j), (m, n), ::Down) = (i,j)
+map_ind((i,j), (m, n), ::Left) = (m-j+1, i)
+map_ind((i,j), (m, n), ::Right) = (j, n-i+1)
+
+function get_grid(src_grid::AbstractArray{Bool, 3}, window_size, pos::CartesianIndex{2}, dir::AbstractDirection)
+    dest_grid = falses(get_num_objects(src_grid), window_size...)
+    get_grid!(dest_grid, src_grid, pos, dir)
+    return dest_grid
+end
+
+function get_grid!(dest_grid::AbstractArray{Bool, 3}, src_grid::AbstractArray{Bool, 3}, pos::CartesianIndex{2}, dir::AbstractDirection)
+    window_inds_size = (get_height(dest_grid), get_width(dest_grid))
+    window_inds = get_grid_inds(pos.I, window_size, dir)
+
+    valid_inds_size = (get_height(src_grid), get_width(src_grid))
+    valid_inds = CartesianIndices(valid_inds_size)
+
+    for ind in CartesianIndices(window_inds_size)
+        pos = window_inds[ind]
+        if pos ∈ valid_inds
+            dest_grid[:, map_ind(ind.I, window_inds_size, dir)...] .= src_grid[:, pos]
+        end
+    end
+
+    return dest_grid
+end
+
 #####
 # utils
 #####

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -67,12 +67,12 @@ function Agent(; inventory_type = Union{Nothing, AbstractObject}, color = :green
     Agent{inventory_type, color}(pos, dir, inventory)
 end
 
-get_char(agent::Agent, ::Center) = '☻'
-get_char(agent::Agent, ::Up) = '↑'
-get_char(agent::Agent, ::Down) = '↓'
-get_char(agent::Agent, ::Left) = '←'
-get_char(agent::Agent, ::Right) = '→'
-get_char(agent::Agent) = get_char(agent, get_dir(agent))
+get_char(::Type{<:Agent}, ::Center) = '☻'
+get_char(::Type{<:Agent}, ::Up) = '↑'
+get_char(::Type{<:Agent}, ::Down) = '↓'
+get_char(::Type{<:Agent}, ::Left) = '←'
+get_char(::Type{<:Agent}, ::Right) = '→'
+get_char(agent::Agent) = get_char(typeof(agent), get_dir(agent))
 
 get_color(agent::Agent{I, C}) where {I, C} = C
 get_dir(agent::Agent) = agent.dir

--- a/src/terminal_rendering.jl
+++ b/src/terminal_rendering.jl
@@ -1,23 +1,21 @@
-get_grid(env::AbstractGridWorld, ::Val{:full_view}) = get_grid(env)
-get_grid(env::AbstractGridWorld, ::Val{:agent_view}) = get_agent_view(env)
+get_grid(env::AbstractGridWorld, ::Val{:global}) = get_grid(env)
+get_grid(env::AbstractGridWorld, ::Val{:local}) = get_agent_view(env)
 
-get_agent_pos(env::AbstractGridWorld, ::Val{:full_view}) = get_agent_pos(env)
-get_agent_pos(env::AbstractGridWorld, view_type_val::Val{:agent_view}) = get_agent_pos(env, view_type_val, get_navigation_style(env))
-get_agent_pos(env::AbstractGridWorld, view_type_val::Val{:agent_view}, ::DirectedNavigation) = CartesianIndex(1, size(get_grid(env, view_type_val), 3) ÷ 2 + 1)
-function get_agent_pos(env::AbstractGridWorld, view_type_val::Val{:agent_view}, ::UndirectedNavigation)
+get_agent_pos(env::AbstractGridWorld, ::Val{:global}) = get_agent_pos(env)
+get_agent_pos(env::AbstractGridWorld, view_type_val::Val{:local}) = get_agent_pos(env, view_type_val, get_navigation_style(env))
+get_agent_pos(env::AbstractGridWorld, view_type_val::Val{:local}, ::DirectedNavigation) = CartesianIndex(1, get_width(get_grid(env, view_type_val)) ÷ 2 + 1)
+function get_agent_pos(env::AbstractGridWorld, view_type_val::Val{:local}, ::UndirectedNavigation)
     grid = get_grid(env, view_type_val)
     CartesianIndex(get_height(grid) ÷ 2 + 1, get_width(grid) ÷ 2 + 1)
 end
 
-get_agent_dir(env::AbstractGridWorld, view_type_val::Val{:full_view}) = get_agent_dir(env, view_type_val, get_navigation_style(env))
-get_agent_dir(env::AbstractGridWorld, ::Val{:full_view}, ::DirectedNavigation) = get_agent_dir(env)
-get_agent_dir(env::AbstractGridWorld, ::Val{:full_view}, ::UndirectedNavigation) = CENTER
-get_agent_dir(env::AbstractGridWorld, view_type_val::Val{:agent_view}) = get_agent_dir(env, view_type_val, get_navigation_style(env))
-get_agent_dir(env::AbstractGridWorld, ::Val{:agent_view}, ::DirectedNavigation) = DOWN
-get_agent_dir(env::AbstractGridWorld, ::Val{:agent_view}, ::UndirectedNavigation) = CENTER
+get_agent_char(env::AbstractGridWorld, ::Val{:global}) = get_char(get_agent(env))
+get_agent_char(env::AbstractGridWorld, view_type_val::Val{:local}) = get_agent_char(env, view_type_val, get_navigation_style(env))
+get_agent_char(env::AbstractGridWorld, ::Val{:local}, ::DirectedNavigation) = get_char(Agent, DOWN)
+get_agent_char(env::AbstractGridWorld, ::Val{:local}, ::UndirectedNavigation) = get_char(get_agent(env))
 
-get_background(env::AbstractGridWorld, pos::CartesianIndex{2}, ::Val{:full_view}) = pos in get_agent_view_inds(env) ? :dark_gray : :black
-get_background(env::AbstractGridWorld, pos::CartesianIndex{2}, ::Val{:agent_view}) = :dark_gray
+get_background(env::AbstractGridWorld, ::Val{:global}, pos::CartesianIndex{2}) = pos in get_agent_view_inds(env) ? :dark_gray : :black
+get_background(env::AbstractGridWorld, ::Val{:local}, pos::CartesianIndex{2}) = :dark_gray
 
 get_color(::Nothing) = :white
 get_char(::Nothing) = '~'
@@ -31,24 +29,23 @@ function get_first_object(grid::AbstractArray{Bool, 3}, objects, pos::CartesianI
     end
 end
 
-function print_grid(io::IO, env::AbstractGridWorld, view_type)
-    grid = get_grid(env, Val{view_type}())
+function Base.show(io::IO, ::MIME"text/plain", env::AbstractGridWorld, view_type::Symbol)
+    view_type_val = Val{view_type}()
+    grid = get_grid(env, view_type_val)
     objects = get_objects(env)
 
-    agent = get_agent(env)
-    agent_pos = get_agent_pos(env, Val{view_type}())
-    agent_dir = get_agent_dir(env, Val{view_type}())
-    agent_char = get_char(agent, agent_dir)
-    agent_color = get_color(agent)
+    agent_pos = get_agent_pos(env, view_type_val)
+    agent_char = get_agent_char(env, view_type_val)
+    agent_color = get_color(get_agent(env))
 
     for i in 1:get_height(grid)
         for j in 1:get_width(grid)
             pos = CartesianIndex(i, j)
             if pos == agent_pos
-                print(io, Crayons.Crayon(background = get_background(env, pos, Val{view_type}()), foreground = agent_color, bold = true, reset = true), agent_char)
+                print(io, Crayons.Crayon(background = get_background(env, view_type_val, pos), foreground = agent_color, bold = true, reset = true), agent_char)
             else
                 object = get_first_object(grid, objects, pos)
-                print(io, Crayons.Crayon(background = get_background(env, pos, Val{view_type}()), foreground = get_color(object), bold = true, reset = true), get_char(object))
+                print(io, Crayons.Crayon(background = get_background(env, view_type_val, pos), foreground = get_color(object), bold = true, reset = true), get_char(object))
             end
         end
         println(io, Crayons.Crayon(reset = true))
@@ -69,12 +66,13 @@ function Base.show(io::IO, ::MIME"text/plain", world::GridWorldBase)
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", env::AbstractGridWorld)
-    println(io, "Full View:")
-    print_grid(io, env, :full_view)
+function Base.show(io::IO, mime::MIME"text/plain", env::AbstractGridWorld)
+    println(io, "Global view:")
+    show(io, mime, env, :global)
     println(io)
-    println(io, "Agent's View:")
-    print_grid(io, env, :agent_view)
-    println(io, "reward: $(RLBase.reward(env))")
-    println(io, "is_terminated: $(RLBase.is_terminated(env))")
+    println(io, "Local view:")
+    show(io, mime, env, :local)
+    println(io)
+    println(io, "RLBase.reward(env): $(RLBase.reward(env))")
+    println(io, "RLBase.is_terminated(env): $(RLBase.is_terminated(env))")
 end


### PR DESCRIPTION
1. Reduce default agent view size
2. Deprecate `get_agent_layer` and `get_full_view`. Instead, have a single method `get_grid_with_agent_layer`.
3. Update `RLBase.state` method accordingly
4. Bug fixes
    1. Use `get_agent_start_dir` in `SequentialRooms` and `GridRooms`
    2. In `get_grid!` method in `grid_world_base.jl`, use `CartesianIndices(window_inds)` instead of `CartesianIndices(window_size)` to traverse the indices, since the window may be rotated.
5. Increase default grid size of `DoorKey` to (height = 8, width = 8)
6. Use `::AbstractArray{Bool, 3}` directly for annotation instead of `::T where {T<:AbstractArray{Bool, 3}}`
7. Use better names for agent view related methods in `grid_world_base.jl`
8. Cleanup `terminal_rendering.jl`
9. Allow `get_char` for an agent to take agent struct (`Agent`) as an argument.