### PR TITLE
performance fix in get_grid_inds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ DataStructures = "0.18"
 MacroTools = "0.5"
 ReinforcementLearningBase = "0.9"
 Requires = "1.1"
+StaticArrays = "1.1"
 julia = "1"
 
 [extras]

--- a/benchmark/benchmark.md
+++ b/benchmark/benchmark.md
@@ -1,4 +1,4 @@
-Date: 2021_04_01_23_28_19
+Date: 2021_04_09_00_01_10
 # List of Environments
   1. [EmptyRoomDirected](#emptyroomdirected)
   1. [EmptyRoomUndirected](#emptyroomundirected)
@@ -29,19 +29,19 @@ Date: 2021_04_01_23_28_19
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  2.64 MiB
+memory estimate:  2.72 MiB
 
-allocs estimate:  76390
+allocs estimate:  81959
 
-minimum time:     13.941 ms (0.00% GC)
+minimum time:     15.295 ms (0.00% GC)
 
-median time:      14.315 ms (0.00% GC)
+median time:      15.609 ms (0.00% GC)
 
-mean time:        14.784 ms (2.35% GC)
+mean time:        16.119 ms (2.04% GC)
 
-maximum time:     22.721 ms (30.99% GC)
+maximum time:     38.186 ms (14.14% GC)
 
-samples:          339
+samples:          311
 
 evals/sample:     1
 
@@ -51,17 +51,17 @@ memory estimate:  320 bytes
 
 allocs estimate:  6
 
-minimum time:     753.068 ns (0.00% GC)
+minimum time:     947.273 ns (0.00% GC)
 
-median time:      802.417 ns (0.00% GC)
+median time:      1.099 μs (0.00% GC)
 
-mean time:        850.155 ns (3.59% GC)
+mean time:        1.103 μs (0.00% GC)
 
-maximum time:     46.008 μs (97.81% GC)
+maximum time:     4.111 μs (0.00% GC)
 
 samples:          10000
 
-evals/sample:     103
+evals/sample:     11
 
 #### RLBase.reset!(env)
 
@@ -69,17 +69,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     250.111 ns (0.00% GC)
+minimum time:     219.640 ns (0.00% GC)
 
-median time:      274.815 ns (0.00% GC)
+median time:      236.322 ns (0.00% GC)
 
-mean time:        307.756 ns (0.00% GC)
+mean time:        237.893 ns (0.00% GC)
 
-maximum time:     965.910 ns (0.00% GC)
+maximum time:     455.303 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     343
+evals/sample:     469
 
 #### RLBase.state(env)
 
@@ -87,13 +87,13 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     1.247 μs (0.00% GC)
+minimum time:     1.566 μs (0.00% GC)
 
-median time:      1.304 μs (0.00% GC)
+median time:      1.588 μs (0.00% GC)
 
-mean time:        1.356 μs (0.00% GC)
+mean time:        1.640 μs (0.00% GC)
 
-maximum time:     5.319 μs (0.00% GC)
+maximum time:     5.144 μs (0.00% GC)
 
 samples:          10000
 
@@ -105,13 +105,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.529 ns (0.00% GC)
+minimum time:     2.442 ns (0.00% GC)
 
-median time:      2.631 ns (0.00% GC)
+median time:      2.541 ns (0.00% GC)
 
-mean time:        2.648 ns (0.00% GC)
+mean time:        2.600 ns (0.00% GC)
 
-maximum time:     34.551 ns (0.00% GC)
+maximum time:     34.460 ns (0.00% GC)
 
 samples:          10000
 
@@ -123,13 +123,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.814 ns (0.00% GC)
+minimum time:     1.820 ns (0.00% GC)
 
-median time:      1.891 ns (0.00% GC)
+median time:      1.857 ns (0.00% GC)
 
-mean time:        1.925 ns (0.00% GC)
+mean time:        1.885 ns (0.00% GC)
 
-maximum time:     33.608 ns (0.00% GC)
+maximum time:     33.659 ns (0.00% GC)
 
 samples:          10000
 
@@ -141,13 +141,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.880 ns (0.00% GC)
+minimum time:     1.834 ns (0.00% GC)
 
-median time:      1.891 ns (0.00% GC)
+median time:      1.871 ns (0.00% GC)
 
-mean time:        1.987 ns (0.00% GC)
+mean time:        1.905 ns (0.00% GC)
 
-maximum time:     42.654 ns (0.00% GC)
+maximum time:     33.361 ns (0.00% GC)
 
 samples:          10000
 
@@ -159,35 +159,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     49.823 ns (0.00% GC)
+minimum time:     60.884 ns (0.00% GC)
 
-median time:      94.260 ns (0.00% GC)
+median time:      63.001 ns (0.00% GC)
 
-mean time:        86.933 ns (0.00% GC)
+mean time:        63.823 ns (0.00% GC)
 
-maximum time:     4.053 μs (0.00% GC)
+maximum time:     144.802 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     987
+evals/sample:     976
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  80 bytes
 
-allocs estimate:  2
+allocs estimate:  3
 
-minimum time:     44.088 ns (0.00% GC)
+minimum time:     61.215 ns (0.00% GC)
 
-median time:      48.293 ns (0.00% GC)
+median time:      62.841 ns (0.00% GC)
 
-mean time:        54.034 ns (7.04% GC)
+mean time:        71.293 ns (7.47% GC)
 
-maximum time:     3.247 μs (98.33% GC)
+maximum time:     3.977 μs (97.23% GC)
 
 samples:          10000
 
-evals/sample:     984
+evals/sample:     976
 
 #### env(GridWorlds.TurnLeft())
 
@@ -195,17 +195,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     47.121 ns (0.00% GC)
+minimum time:     62.070 ns (0.00% GC)
 
-median time:      92.748 ns (0.00% GC)
+median time:      64.147 ns (0.00% GC)
 
-mean time:        87.254 ns (0.00% GC)
+mean time:        64.806 ns (0.00% GC)
 
-maximum time:     4.193 μs (0.00% GC)
+maximum time:     138.624 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     987
+evals/sample:     976
 
 # EmptyRoomUndirected
 
@@ -215,15 +215,15 @@ memory estimate:  1.68 MiB
 
 allocs estimate:  40006
 
-minimum time:     16.111 ms (0.00% GC)
+minimum time:     15.436 ms (0.00% GC)
 
-median time:      16.878 ms (0.00% GC)
+median time:      15.573 ms (0.00% GC)
 
-mean time:        19.615 ms (0.97% GC)
+mean time:        15.841 ms (1.15% GC)
 
-maximum time:     50.337 ms (0.00% GC)
+maximum time:     21.680 ms (0.00% GC)
 
-samples:          256
+samples:          316
 
 evals/sample:     1
 
@@ -233,17 +233,17 @@ memory estimate:  304 bytes
 
 allocs estimate:  6
 
-minimum time:     804.286 ns (0.00% GC)
+minimum time:     888.382 ns (0.00% GC)
 
-median time:      1.324 μs (0.00% GC)
+median time:      965.206 ns (0.00% GC)
 
-mean time:        1.512 μs (3.35% GC)
+mean time:        1.013 μs (3.00% GC)
 
-maximum time:     155.842 μs (98.78% GC)
+maximum time:     154.700 μs (99.15% GC)
 
 samples:          10000
 
-evals/sample:     70
+evals/sample:     34
 
 #### RLBase.reset!(env)
 
@@ -251,17 +251,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     218.552 ns (0.00% GC)
+minimum time:     167.325 ns (0.00% GC)
 
-median time:      267.069 ns (0.00% GC)
+median time:      179.556 ns (0.00% GC)
 
-mean time:        299.351 ns (0.00% GC)
+mean time:        180.525 ns (0.00% GC)
 
-maximum time:     877.237 ns (0.00% GC)
+maximum time:     269.310 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     451
+evals/sample:     741
 
 #### RLBase.state(env)
 
@@ -269,13 +269,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.734 μs (0.00% GC)
+minimum time:     1.247 μs (0.00% GC)
 
-median time:      2.037 μs (0.00% GC)
+median time:      1.287 μs (0.00% GC)
 
-mean time:        2.469 μs (0.00% GC)
+mean time:        1.340 μs (0.00% GC)
 
-maximum time:     26.670 μs (0.00% GC)
+maximum time:     6.582 μs (0.00% GC)
 
 samples:          10000
 
@@ -287,13 +287,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.883 ns (0.00% GC)
+minimum time:     2.449 ns (0.00% GC)
 
-median time:      2.431 ns (0.00% GC)
+median time:      2.549 ns (0.00% GC)
 
-mean time:        2.862 ns (0.00% GC)
+mean time:        2.598 ns (0.00% GC)
 
-maximum time:     110.182 ns (0.00% GC)
+maximum time:     34.378 ns (0.00% GC)
 
 samples:          10000
 
@@ -305,13 +305,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      3.605 ns (0.00% GC)
+median time:      1.850 ns (0.00% GC)
 
-mean time:        3.615 ns (0.00% GC)
+mean time:        1.880 ns (0.00% GC)
 
-maximum time:     94.407 ns (0.00% GC)
+maximum time:     14.960 ns (0.00% GC)
 
 samples:          10000
 
@@ -323,13 +323,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.897 ns (0.00% GC)
+minimum time:     1.834 ns (0.00% GC)
 
-median time:      2.251 ns (0.00% GC)
+median time:      1.889 ns (0.00% GC)
 
-mean time:        2.902 ns (0.00% GC)
+mean time:        1.909 ns (0.00% GC)
 
-maximum time:     66.840 ns (0.00% GC)
+maximum time:     15.397 ns (0.00% GC)
 
 samples:          10000
 
@@ -341,13 +341,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.915 ns (0.00% GC)
+minimum time:     12.322 ns (0.00% GC)
 
-median time:      14.253 ns (0.00% GC)
+median time:      13.327 ns (0.00% GC)
 
-mean time:        18.481 ns (0.00% GC)
+mean time:        13.424 ns (0.00% GC)
 
-maximum time:     107.582 ns (0.00% GC)
+maximum time:     46.362 ns (0.00% GC)
 
 samples:          10000
 
@@ -359,13 +359,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.616 ns (0.00% GC)
+minimum time:     12.332 ns (0.00% GC)
 
-median time:      14.773 ns (0.00% GC)
+median time:      12.984 ns (0.00% GC)
 
-mean time:        18.453 ns (0.00% GC)
+mean time:        13.425 ns (0.00% GC)
 
-maximum time:     134.668 ns (0.00% GC)
+maximum time:     46.562 ns (0.00% GC)
 
 samples:          10000
 
@@ -377,13 +377,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.014 ns (0.00% GC)
+minimum time:     12.969 ns (0.00% GC)
 
-median time:      14.855 ns (0.00% GC)
+median time:      13.308 ns (0.00% GC)
 
-mean time:        19.597 ns (0.00% GC)
+mean time:        13.749 ns (0.00% GC)
 
-maximum time:     359.150 ns (0.00% GC)
+maximum time:     47.316 ns (0.00% GC)
 
 samples:          10000
 
@@ -395,13 +395,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.266 ns (0.00% GC)
+minimum time:     13.093 ns (0.00% GC)
 
-median time:      15.819 ns (0.00% GC)
+median time:      13.810 ns (0.00% GC)
 
-mean time:        20.027 ns (0.00% GC)
+mean time:        14.189 ns (0.00% GC)
 
-maximum time:     222.487 ns (0.00% GC)
+maximum time:     47.524 ns (0.00% GC)
 
 samples:          10000
 
@@ -411,19 +411,19 @@ evals/sample:     998
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  2.64 MiB
+memory estimate:  2.71 MiB
 
-allocs estimate:  76439
+allocs estimate:  81373
 
-minimum time:     21.186 ms (0.00% GC)
+minimum time:     15.549 ms (0.00% GC)
 
-median time:      26.617 ms (0.00% GC)
+median time:      15.950 ms (0.00% GC)
 
-mean time:        27.830 ms (2.50% GC)
+mean time:        16.332 ms (2.06% GC)
 
-maximum time:     49.223 ms (29.93% GC)
+maximum time:     21.917 ms (25.67% GC)
 
-samples:          180
+samples:          307
 
 evals/sample:     1
 
@@ -433,13 +433,13 @@ memory estimate:  752 bytes
 
 allocs estimate:  11
 
-minimum time:     1.762 μs (0.00% GC)
+minimum time:     1.722 μs (0.00% GC)
 
-median time:      2.737 μs (0.00% GC)
+median time:      1.882 μs (0.00% GC)
 
-mean time:        3.474 μs (3.01% GC)
+mean time:        1.983 μs (3.00% GC)
 
-maximum time:     1.053 ms (99.17% GC)
+maximum time:     598.328 μs (99.43% GC)
 
 samples:          10000
 
@@ -451,17 +451,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     310.702 ns (0.00% GC)
+minimum time:     243.919 ns (0.00% GC)
 
-median time:      453.467 ns (0.00% GC)
+median time:      260.311 ns (0.00% GC)
 
-mean time:        489.874 ns (0.00% GC)
+mean time:        262.062 ns (0.00% GC)
 
-maximum time:     2.830 μs (0.00% GC)
+maximum time:     437.563 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     228
+evals/sample:     405
 
 #### RLBase.state(env)
 
@@ -469,13 +469,13 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     1.735 μs (0.00% GC)
+minimum time:     1.280 μs (0.00% GC)
 
-median time:      3.276 μs (0.00% GC)
+median time:      1.307 μs (0.00% GC)
 
-mean time:        3.210 μs (0.00% GC)
+mean time:        1.358 μs (0.00% GC)
 
-maximum time:     105.686 μs (0.00% GC)
+maximum time:     4.690 μs (0.00% GC)
 
 samples:          10000
 
@@ -487,13 +487,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.623 ns (0.00% GC)
+minimum time:     2.442 ns (0.00% GC)
 
-median time:      3.232 ns (0.00% GC)
+median time:      2.559 ns (0.00% GC)
 
-mean time:        3.819 ns (0.00% GC)
+mean time:        2.592 ns (0.00% GC)
 
-maximum time:     69.598 ns (0.00% GC)
+maximum time:     34.717 ns (0.00% GC)
 
 samples:          10000
 
@@ -505,13 +505,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     1.819 ns (0.00% GC)
 
-median time:      2.888 ns (0.00% GC)
+median time:      1.876 ns (0.00% GC)
 
-mean time:        3.051 ns (0.00% GC)
+mean time:        1.896 ns (0.00% GC)
 
-maximum time:     87.226 ns (0.00% GC)
+maximum time:     33.898 ns (0.00% GC)
 
 samples:          10000
 
@@ -523,13 +523,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.032 ns (0.00% GC)
+minimum time:     1.819 ns (0.00% GC)
 
-median time:      2.502 ns (0.00% GC)
+median time:      1.839 ns (0.00% GC)
 
-mean time:        2.738 ns (0.00% GC)
+mean time:        1.878 ns (0.00% GC)
 
-maximum time:     59.860 ns (0.00% GC)
+maximum time:     33.691 ns (0.00% GC)
 
 samples:          10000
 
@@ -541,35 +541,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     49.860 ns (0.00% GC)
+minimum time:     62.738 ns (0.00% GC)
 
-median time:      56.023 ns (0.00% GC)
+median time:      64.469 ns (0.00% GC)
 
-mean time:        70.317 ns (0.00% GC)
+mean time:        65.376 ns (0.00% GC)
 
-maximum time:     296.118 ns (0.00% GC)
+maximum time:     140.105 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     986
+evals/sample:     976
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  80 bytes
 
-allocs estimate:  2
+allocs estimate:  3
 
-minimum time:     45.092 ns (0.00% GC)
+minimum time:     62.204 ns (0.00% GC)
 
-median time:      56.285 ns (0.00% GC)
+median time:      63.658 ns (0.00% GC)
 
-mean time:        75.202 ns (10.38% GC)
+mean time:        71.368 ns (7.47% GC)
 
-maximum time:     7.661 μs (98.60% GC)
+maximum time:     3.651 μs (98.14% GC)
 
 samples:          10000
 
-evals/sample:     989
+evals/sample:     974
 
 #### env(GridWorlds.TurnLeft())
 
@@ -577,17 +577,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     50.102 ns (0.00% GC)
+minimum time:     61.724 ns (0.00% GC)
 
-median time:      59.903 ns (0.00% GC)
+median time:      63.525 ns (0.00% GC)
 
-mean time:        74.151 ns (0.00% GC)
+mean time:        64.533 ns (0.00% GC)
 
-maximum time:     235.176 ns (0.00% GC)
+maximum time:     153.427 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     987
+evals/sample:     976
 
 # GridRoomsUndirected
 
@@ -597,15 +597,15 @@ memory estimate:  1.68 MiB
 
 allocs estimate:  40011
 
-minimum time:     15.673 ms (0.00% GC)
+minimum time:     15.646 ms (0.00% GC)
 
-median time:      22.272 ms (0.00% GC)
+median time:      15.830 ms (0.00% GC)
 
-mean time:        22.222 ms (1.14% GC)
+mean time:        16.073 ms (1.07% GC)
 
-maximum time:     42.614 ms (0.00% GC)
+maximum time:     20.868 ms (23.15% GC)
 
-samples:          226
+samples:          311
 
 evals/sample:     1
 
@@ -615,13 +615,13 @@ memory estimate:  736 bytes
 
 allocs estimate:  11
 
-minimum time:     1.672 μs (0.00% GC)
+minimum time:     1.622 μs (0.00% GC)
 
-median time:      3.042 μs (0.00% GC)
+median time:      1.805 μs (0.00% GC)
 
-mean time:        3.331 μs (2.30% GC)
+mean time:        1.888 μs (3.15% GC)
 
-maximum time:     771.933 μs (99.39% GC)
+maximum time:     600.066 μs (99.18% GC)
 
 samples:          10000
 
@@ -633,17 +633,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     246.338 ns (0.00% GC)
+minimum time:     187.105 ns (0.00% GC)
 
-median time:      339.652 ns (0.00% GC)
+median time:      199.904 ns (0.00% GC)
 
-mean time:        354.142 ns (0.00% GC)
+mean time:        201.246 ns (0.00% GC)
 
-maximum time:     918.152 ns (0.00% GC)
+maximum time:     322.741 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     349
+evals/sample:     646
 
 #### RLBase.state(env)
 
@@ -651,13 +651,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.384 μs (0.00% GC)
+minimum time:     1.517 μs (0.00% GC)
 
-median time:      2.065 μs (0.00% GC)
+median time:      1.533 μs (0.00% GC)
 
-mean time:        2.195 μs (0.00% GC)
+mean time:        1.586 μs (0.00% GC)
 
-maximum time:     23.217 μs (0.00% GC)
+maximum time:     5.138 μs (0.00% GC)
 
 samples:          10000
 
@@ -669,13 +669,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.250 ns (0.00% GC)
+minimum time:     1.822 ns (0.00% GC)
 
-median time:      2.819 ns (0.00% GC)
+median time:      1.893 ns (0.00% GC)
 
-mean time:        3.106 ns (0.00% GC)
+mean time:        1.910 ns (0.00% GC)
 
-maximum time:     88.800 ns (0.00% GC)
+maximum time:     35.667 ns (0.00% GC)
 
 samples:          10000
 
@@ -687,13 +687,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.883 ns (0.00% GC)
+minimum time:     1.821 ns (0.00% GC)
 
-median time:      2.425 ns (0.00% GC)
+median time:      1.848 ns (0.00% GC)
 
-mean time:        3.046 ns (0.00% GC)
+mean time:        1.878 ns (0.00% GC)
 
-maximum time:     669.258 ns (0.00% GC)
+maximum time:     10.387 ns (0.00% GC)
 
 samples:          10000
 
@@ -705,13 +705,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.896 ns (0.00% GC)
+minimum time:     1.833 ns (0.00% GC)
 
-median time:      2.445 ns (0.00% GC)
+median time:      1.871 ns (0.00% GC)
 
-mean time:        2.930 ns (0.00% GC)
+mean time:        1.899 ns (0.00% GC)
 
-maximum time:     74.129 ns (0.00% GC)
+maximum time:     35.464 ns (0.00% GC)
 
 samples:          10000
 
@@ -723,13 +723,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.912 ns (0.00% GC)
+minimum time:     12.625 ns (0.00% GC)
 
-median time:      15.164 ns (0.00% GC)
+median time:      13.279 ns (0.00% GC)
 
-mean time:        19.424 ns (0.00% GC)
+mean time:        13.615 ns (0.00% GC)
 
-maximum time:     115.689 ns (0.00% GC)
+maximum time:     45.782 ns (0.00% GC)
 
 samples:          10000
 
@@ -741,13 +741,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.156 ns (0.00% GC)
+minimum time:     13.039 ns (0.00% GC)
 
-median time:      14.596 ns (0.00% GC)
+median time:      14.080 ns (0.00% GC)
 
-mean time:        19.707 ns (0.00% GC)
+mean time:        14.444 ns (0.00% GC)
 
-maximum time:     137.897 ns (0.00% GC)
+maximum time:     49.506 ns (0.00% GC)
 
 samples:          10000
 
@@ -759,13 +759,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.602 ns (0.00% GC)
+minimum time:     12.655 ns (0.00% GC)
 
-median time:      13.978 ns (0.00% GC)
+median time:      13.353 ns (0.00% GC)
 
-mean time:        18.676 ns (0.00% GC)
+mean time:        13.741 ns (0.00% GC)
 
-maximum time:     1.224 μs (0.00% GC)
+maximum time:     50.949 ns (0.00% GC)
 
 samples:          10000
 
@@ -777,13 +777,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.080 ns (0.00% GC)
+minimum time:     12.334 ns (0.00% GC)
 
-median time:      15.346 ns (0.00% GC)
+median time:      13.703 ns (0.00% GC)
 
-mean time:        19.351 ns (0.00% GC)
+mean time:        14.149 ns (0.00% GC)
 
-maximum time:     645.208 ns (0.00% GC)
+maximum time:     49.254 ns (0.00% GC)
 
 samples:          10000
 
@@ -793,55 +793,55 @@ evals/sample:     998
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  218.09 MiB
+memory estimate:  11.68 MiB
 
-allocs estimate:  1376292
+allocs estimate:  141305
 
-minimum time:     367.021 ms (8.10% GC)
+minimum time:     52.988 ms (0.00% GC)
 
-median time:      393.814 ms (7.86% GC)
+median time:      54.071 ms (0.00% GC)
 
-mean time:        391.281 ms (8.11% GC)
+mean time:        55.013 ms (1.72% GC)
 
-maximum time:     432.951 ms (7.79% GC)
+maximum time:     60.288 ms (0.00% GC)
 
-samples:          13
+samples:          91
 
 evals/sample:     1
 
 #### GridWorlds.SequentialRoomsDirected()
 
-memory estimate:  1.23 MiB
+memory estimate:  74.55 KiB
 
-allocs estimate:  9441
+allocs estimate:  510
 
-minimum time:     1.046 ms (0.00% GC)
+minimum time:     55.209 μs (0.00% GC)
 
-median time:      2.453 ms (0.00% GC)
+median time:      67.579 μs (0.00% GC)
 
-mean time:        2.947 ms (9.27% GC)
+mean time:        74.523 μs (6.66% GC)
 
-maximum time:     14.625 ms (57.08% GC)
+maximum time:     3.002 ms (95.48% GC)
 
-samples:          1694
+samples:          10000
 
 evals/sample:     1
 
 #### RLBase.reset!(env)
 
-memory estimate:  1.23 MiB
+memory estimate:  73.56 KiB
 
-allocs estimate:  9436
+allocs estimate:  505
 
-minimum time:     1.101 ms (0.00% GC)
+minimum time:     54.495 μs (0.00% GC)
 
-median time:      2.610 ms (0.00% GC)
+median time:      65.529 μs (0.00% GC)
 
-mean time:        2.956 ms (9.17% GC)
+mean time:        72.305 μs (7.09% GC)
 
-maximum time:     18.374 ms (0.00% GC)
+maximum time:     2.841 ms (95.62% GC)
 
-samples:          1691
+samples:          10000
 
 evals/sample:     1
 
@@ -851,13 +851,195 @@ memory estimate:  240 bytes
 
 allocs estimate:  5
 
-minimum time:     4.732 μs (0.00% GC)
+minimum time:     3.278 μs (0.00% GC)
 
-median time:      5.690 μs (0.00% GC)
+median time:      3.302 μs (0.00% GC)
 
-mean time:        6.670 μs (0.00% GC)
+mean time:        3.399 μs (0.00% GC)
 
-maximum time:     19.707 μs (0.00% GC)
+maximum time:     7.768 μs (0.00% GC)
+
+samples:          10000
+
+evals/sample:     8
+
+#### RLBase.action_space(env)
+
+memory estimate:  0 bytes
+
+allocs estimate:  0
+
+minimum time:     2.441 ns (0.00% GC)
+
+median time:      2.546 ns (0.00% GC)
+
+mean time:        2.593 ns (0.00% GC)
+
+maximum time:     34.094 ns (0.00% GC)
+
+samples:          10000
+
+evals/sample:     1000
+
+#### RLBase.is_terminated(env)
+
+memory estimate:  0 bytes
+
+allocs estimate:  0
+
+minimum time:     1.821 ns (0.00% GC)
+
+median time:      1.882 ns (0.00% GC)
+
+mean time:        1.904 ns (0.00% GC)
+
+maximum time:     15.326 ns (0.00% GC)
+
+samples:          10000
+
+evals/sample:     1000
+
+#### RLBase.reward(env)
+
+memory estimate:  0 bytes
+
+allocs estimate:  0
+
+minimum time:     1.818 ns (0.00% GC)
+
+median time:      1.831 ns (0.00% GC)
+
+mean time:        1.971 ns (0.00% GC)
+
+maximum time:     33.748 ns (0.00% GC)
+
+samples:          10000
+
+evals/sample:     1000
+
+#### env(GridWorlds.TurnRight())
+
+memory estimate:  0 bytes
+
+allocs estimate:  0
+
+minimum time:     61.425 ns (0.00% GC)
+
+median time:      63.805 ns (0.00% GC)
+
+mean time:        64.510 ns (0.00% GC)
+
+maximum time:     122.051 ns (0.00% GC)
+
+samples:          10000
+
+evals/sample:     976
+
+#### env(GridWorlds.MoveForward())
+
+memory estimate:  80 bytes
+
+allocs estimate:  3
+
+minimum time:     71.960 ns (0.00% GC)
+
+median time:      74.345 ns (0.00% GC)
+
+mean time:        81.126 ns (5.78% GC)
+
+maximum time:     3.641 μs (97.48% GC)
+
+samples:          10000
+
+evals/sample:     963
+
+#### env(GridWorlds.TurnLeft())
+
+memory estimate:  0 bytes
+
+allocs estimate:  0
+
+minimum time:     61.453 ns (0.00% GC)
+
+median time:      62.867 ns (0.00% GC)
+
+mean time:        63.616 ns (0.00% GC)
+
+maximum time:     142.632 ns (0.00% GC)
+
+samples:          10000
+
+evals/sample:     976
+
+# SequentialRoomsUndirected
+
+#### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
+
+memory estimate:  10.60 MiB
+
+allocs estimate:  99452
+
+minimum time:     55.316 ms (0.00% GC)
+
+median time:      55.674 ms (0.00% GC)
+
+mean time:        56.610 ms (1.32% GC)
+
+maximum time:     62.793 ms (0.00% GC)
+
+samples:          89
+
+evals/sample:     1
+
+#### GridWorlds.SequentialRoomsUndirected()
+
+memory estimate:  74.36 KiB
+
+allocs estimate:  510
+
+minimum time:     54.868 μs (0.00% GC)
+
+median time:      65.840 μs (0.00% GC)
+
+mean time:        72.606 μs (7.09% GC)
+
+maximum time:     2.797 ms (94.43% GC)
+
+samples:          10000
+
+evals/sample:     1
+
+#### RLBase.reset!(env)
+
+memory estimate:  73.73 KiB
+
+allocs estimate:  505
+
+minimum time:     54.083 μs (0.00% GC)
+
+median time:      65.336 μs (0.00% GC)
+
+mean time:        72.187 μs (7.09% GC)
+
+maximum time:     2.852 ms (95.14% GC)
+
+samples:          10000
+
+evals/sample:     1
+
+#### RLBase.state(env)
+
+memory estimate:  160 bytes
+
+allocs estimate:  2
+
+minimum time:     4.715 μs (0.00% GC)
+
+median time:      4.733 μs (0.00% GC)
+
+mean time:        4.851 μs (0.00% GC)
+
+maximum time:     13.416 μs (0.00% GC)
 
 samples:          10000
 
@@ -869,13 +1051,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.621 ns (0.00% GC)
+minimum time:     1.822 ns (0.00% GC)
 
-median time:      3.236 ns (0.00% GC)
+median time:      1.885 ns (0.00% GC)
 
-mean time:        3.901 ns (0.00% GC)
+mean time:        1.889 ns (0.00% GC)
 
-maximum time:     22.069 ns (0.00% GC)
+maximum time:     15.023 ns (0.00% GC)
 
 samples:          10000
 
@@ -887,13 +1069,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     1.817 ns (0.00% GC)
 
-median time:      2.555 ns (0.00% GC)
+median time:      1.845 ns (0.00% GC)
 
-mean time:        2.806 ns (0.00% GC)
+mean time:        1.875 ns (0.00% GC)
 
-maximum time:     264.884 ns (0.00% GC)
+maximum time:     16.190 ns (0.00% GC)
 
 samples:          10000
 
@@ -905,195 +1087,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.835 ns (0.00% GC)
 
-median time:      2.561 ns (0.00% GC)
+median time:      1.901 ns (0.00% GC)
 
-mean time:        2.745 ns (0.00% GC)
+mean time:        1.912 ns (0.00% GC)
 
-maximum time:     74.297 ns (0.00% GC)
-
-samples:          10000
-
-evals/sample:     1000
-
-#### env(GridWorlds.TurnRight())
-
-memory estimate:  0 bytes
-
-allocs estimate:  0
-
-minimum time:     50.617 ns (0.00% GC)
-
-median time:      65.397 ns (0.00% GC)
-
-mean time:        77.930 ns (0.00% GC)
-
-maximum time:     2.906 μs (0.00% GC)
-
-samples:          10000
-
-evals/sample:     987
-
-#### env(GridWorlds.MoveForward())
-
-memory estimate:  64 bytes
-
-allocs estimate:  2
-
-minimum time:     45.934 ns (0.00% GC)
-
-median time:      65.715 ns (0.00% GC)
-
-mean time:        81.767 ns (7.65% GC)
-
-maximum time:     7.345 μs (99.24% GC)
-
-samples:          10000
-
-evals/sample:     988
-
-#### env(GridWorlds.TurnLeft())
-
-memory estimate:  0 bytes
-
-allocs estimate:  0
-
-minimum time:     50.378 ns (0.00% GC)
-
-median time:      61.756 ns (0.00% GC)
-
-mean time:        76.810 ns (0.00% GC)
-
-maximum time:     1.297 μs (0.00% GC)
-
-samples:          10000
-
-evals/sample:     987
-
-# SequentialRoomsUndirected
-
-#### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
-
-memory estimate:  210.98 MiB
-
-allocs estimate:  1322806
-
-minimum time:     325.347 ms (5.55% GC)
-
-median time:      366.535 ms (7.19% GC)
-
-mean time:        373.387 ms (7.19% GC)
-
-maximum time:     417.766 ms (7.34% GC)
-
-samples:          14
-
-evals/sample:     1
-
-#### GridWorlds.SequentialRoomsUndirected()
-
-memory estimate:  1.23 MiB
-
-allocs estimate:  9437
-
-minimum time:     1.094 ms (0.00% GC)
-
-median time:      2.427 ms (0.00% GC)
-
-mean time:        2.808 ms (9.18% GC)
-
-maximum time:     11.631 ms (60.70% GC)
-
-samples:          1777
-
-evals/sample:     1
-
-#### RLBase.reset!(env)
-
-memory estimate:  1.23 MiB
-
-allocs estimate:  9432
-
-minimum time:     1.068 ms (0.00% GC)
-
-median time:      2.400 ms (0.00% GC)
-
-mean time:        2.745 ms (9.33% GC)
-
-maximum time:     12.374 ms (55.17% GC)
-
-samples:          1820
-
-evals/sample:     1
-
-#### RLBase.state(env)
-
-memory estimate:  160 bytes
-
-allocs estimate:  2
-
-minimum time:     5.198 μs (0.00% GC)
-
-median time:      5.786 μs (0.00% GC)
-
-mean time:        6.939 μs (0.00% GC)
-
-maximum time:     36.529 μs (0.00% GC)
-
-samples:          10000
-
-evals/sample:     6
-
-#### RLBase.action_space(env)
-
-memory estimate:  0 bytes
-
-allocs estimate:  0
-
-minimum time:     1.883 ns (0.00% GC)
-
-median time:      2.359 ns (0.00% GC)
-
-mean time:        2.932 ns (0.00% GC)
-
-maximum time:     41.688 ns (0.00% GC)
-
-samples:          10000
-
-evals/sample:     1000
-
-#### RLBase.is_terminated(env)
-
-memory estimate:  0 bytes
-
-allocs estimate:  0
-
-minimum time:     1.883 ns (0.00% GC)
-
-median time:      4.100 ns (0.00% GC)
-
-mean time:        4.317 ns (0.00% GC)
-
-maximum time:     1.199 μs (0.00% GC)
-
-samples:          10000
-
-evals/sample:     1000
-
-#### RLBase.reward(env)
-
-memory estimate:  0 bytes
-
-allocs estimate:  0
-
-minimum time:     1.897 ns (0.00% GC)
-
-median time:      2.240 ns (0.00% GC)
-
-mean time:        2.990 ns (0.00% GC)
-
-maximum time:     33.418 ns (0.00% GC)
+maximum time:     8.792 ns (0.00% GC)
 
 samples:          10000
 
@@ -1105,13 +1105,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.833 ns (0.00% GC)
+minimum time:     12.597 ns (0.00% GC)
 
-median time:      14.603 ns (0.00% GC)
+median time:      12.990 ns (0.00% GC)
 
-mean time:        18.307 ns (0.00% GC)
+mean time:        13.443 ns (0.00% GC)
 
-maximum time:     417.803 ns (0.00% GC)
+maximum time:     47.577 ns (0.00% GC)
 
 samples:          10000
 
@@ -1123,13 +1123,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.921 ns (0.00% GC)
+minimum time:     12.600 ns (0.00% GC)
 
-median time:      14.745 ns (0.00% GC)
+median time:      13.008 ns (0.00% GC)
 
-mean time:        18.590 ns (0.00% GC)
+mean time:        13.564 ns (0.00% GC)
 
-maximum time:     58.443 ns (0.00% GC)
+maximum time:     49.858 ns (0.00% GC)
 
 samples:          10000
 
@@ -1141,13 +1141,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.576 ns (0.00% GC)
+minimum time:     12.365 ns (0.00% GC)
 
-median time:      13.505 ns (0.00% GC)
+median time:      12.510 ns (0.00% GC)
 
-mean time:        17.166 ns (0.00% GC)
+mean time:        13.040 ns (0.00% GC)
 
-maximum time:     62.597 ns (0.00% GC)
+maximum time:     82.335 ns (0.00% GC)
 
 samples:          10000
 
@@ -1159,13 +1159,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.793 ns (0.00% GC)
+minimum time:     12.926 ns (0.00% GC)
 
-median time:      14.482 ns (0.00% GC)
+median time:      13.572 ns (0.00% GC)
 
-mean time:        18.682 ns (0.00% GC)
+mean time:        14.002 ns (0.00% GC)
 
-maximum time:     209.889 ns (0.00% GC)
+maximum time:     47.046 ns (0.00% GC)
 
 samples:          10000
 
@@ -1175,35 +1175,35 @@ evals/sample:     998
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  5.18 MiB
+memory estimate:  6.11 MiB
 
-allocs estimate:  102991
+allocs estimate:  133607
 
-minimum time:     25.191 ms (0.00% GC)
+minimum time:     19.242 ms (0.00% GC)
 
-median time:      30.756 ms (0.00% GC)
+median time:      19.778 ms (0.00% GC)
 
-mean time:        32.272 ms (2.89% GC)
+mean time:        20.493 ms (3.39% GC)
 
-maximum time:     51.554 ms (21.02% GC)
+maximum time:     26.581 ms (20.68% GC)
 
-samples:          155
+samples:          244
 
 evals/sample:     1
 
 #### GridWorlds.MazeDirected()
 
-memory estimate:  26.05 KiB
+memory estimate:  33.84 KiB
 
-allocs estimate:  269
+allocs estimate:  500
 
-minimum time:     30.221 μs (0.00% GC)
+minimum time:     36.592 μs (0.00% GC)
 
-median time:      54.619 μs (0.00% GC)
+median time:      38.811 μs (0.00% GC)
 
-mean time:        65.769 μs (5.43% GC)
+mean time:        42.711 μs (6.07% GC)
 
-maximum time:     8.087 ms (97.89% GC)
+maximum time:     3.929 ms (98.18% GC)
 
 samples:          10000
 
@@ -1211,17 +1211,17 @@ evals/sample:     1
 
 #### RLBase.reset!(env)
 
-memory estimate:  25.73 KiB
+memory estimate:  33.53 KiB
 
-allocs estimate:  263
+allocs estimate:  494
 
-minimum time:     28.717 μs (0.00% GC)
+minimum time:     35.444 μs (0.00% GC)
 
-median time:      37.119 μs (0.00% GC)
+median time:      37.561 μs (0.00% GC)
 
-mean time:        53.571 μs (4.28% GC)
+mean time:        41.149 μs (6.17% GC)
 
-maximum time:     5.203 ms (97.97% GC)
+maximum time:     3.998 ms (98.43% GC)
 
 samples:          10000
 
@@ -1233,13 +1233,13 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     1.721 μs (0.00% GC)
+minimum time:     1.561 μs (0.00% GC)
 
-median time:      2.043 μs (0.00% GC)
+median time:      1.582 μs (0.00% GC)
 
-mean time:        2.436 μs (0.00% GC)
+mean time:        1.636 μs (0.00% GC)
 
-maximum time:     10.055 μs (0.00% GC)
+maximum time:     5.059 μs (0.00% GC)
 
 samples:          10000
 
@@ -1251,13 +1251,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.623 ns (0.00% GC)
+minimum time:     2.443 ns (0.00% GC)
 
-median time:      2.839 ns (0.00% GC)
+median time:      2.559 ns (0.00% GC)
 
-mean time:        3.751 ns (0.00% GC)
+mean time:        2.604 ns (0.00% GC)
 
-maximum time:     273.716 ns (0.00% GC)
+maximum time:     35.266 ns (0.00% GC)
 
 samples:          10000
 
@@ -1269,13 +1269,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.822 ns (0.00% GC)
 
-median time:      2.313 ns (0.00% GC)
+median time:      1.845 ns (0.00% GC)
 
-mean time:        2.665 ns (0.00% GC)
+mean time:        1.882 ns (0.00% GC)
 
-maximum time:     173.399 ns (0.00% GC)
+maximum time:     34.857 ns (0.00% GC)
 
 samples:          10000
 
@@ -1287,13 +1287,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      2.625 ns (0.00% GC)
+median time:      1.838 ns (0.00% GC)
 
-mean time:        2.742 ns (0.00% GC)
+mean time:        1.873 ns (0.00% GC)
 
-maximum time:     29.498 ns (0.00% GC)
+maximum time:     14.986 ns (0.00% GC)
 
 samples:          10000
 
@@ -1305,35 +1305,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     49.940 ns (0.00% GC)
+minimum time:     61.349 ns (0.00% GC)
 
-median time:      59.949 ns (0.00% GC)
+median time:      63.154 ns (0.00% GC)
 
-mean time:        73.329 ns (0.00% GC)
+mean time:        63.867 ns (0.00% GC)
 
-maximum time:     226.462 ns (0.00% GC)
+maximum time:     136.617 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     985
+evals/sample:     976
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  80 bytes
 
-allocs estimate:  2
+allocs estimate:  3
 
-minimum time:     44.694 ns (0.00% GC)
+minimum time:     62.102 ns (0.00% GC)
 
-median time:      62.222 ns (0.00% GC)
+median time:      64.525 ns (0.00% GC)
 
-mean time:        77.584 ns (9.30% GC)
+mean time:        72.070 ns (7.42% GC)
 
-maximum time:     9.614 μs (98.88% GC)
+maximum time:     3.575 μs (97.50% GC)
 
 samples:          10000
 
-evals/sample:     989
+evals/sample:     974
 
 #### env(GridWorlds.TurnLeft())
 
@@ -1341,51 +1341,51 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     48.817 ns (0.00% GC)
+minimum time:     61.007 ns (0.00% GC)
 
-median time:      56.404 ns (0.00% GC)
+median time:      63.956 ns (0.00% GC)
 
-mean time:        72.468 ns (0.00% GC)
+mean time:        64.502 ns (0.00% GC)
 
-maximum time:     2.861 μs (0.00% GC)
+maximum time:     115.831 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     988
+evals/sample:     977
 
 # MazeUndirected
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  4.22 MiB
+memory estimate:  5.08 MiB
 
-allocs estimate:  66569
+allocs estimate:  92468
 
-minimum time:     17.325 ms (0.00% GC)
+minimum time:     18.657 ms (0.00% GC)
 
-median time:      18.445 ms (0.00% GC)
+median time:      18.986 ms (0.00% GC)
 
-mean time:        20.125 ms (2.45% GC)
+mean time:        19.698 ms (3.07% GC)
 
-maximum time:     40.895 ms (0.00% GC)
+maximum time:     36.125 ms (19.93% GC)
 
-samples:          249
+samples:          254
 
 evals/sample:     1
 
 #### GridWorlds.MazeUndirected()
 
-memory estimate:  26.03 KiB
+memory estimate:  33.83 KiB
 
-allocs estimate:  269
+allocs estimate:  500
 
-minimum time:     30.180 μs (0.00% GC)
+minimum time:     36.210 μs (0.00% GC)
 
-median time:      47.256 μs (0.00% GC)
+median time:      38.376 μs (0.00% GC)
 
-mean time:        60.488 μs (4.50% GC)
+mean time:        42.078 μs (6.14% GC)
 
-maximum time:     7.903 ms (97.77% GC)
+maximum time:     3.975 ms (98.38% GC)
 
 samples:          10000
 
@@ -1393,17 +1393,17 @@ evals/sample:     1
 
 #### RLBase.reset!(env)
 
-memory estimate:  25.73 KiB
+memory estimate:  33.53 KiB
 
-allocs estimate:  263
+allocs estimate:  494
 
-minimum time:     28.724 μs (0.00% GC)
+minimum time:     35.285 μs (0.00% GC)
 
-median time:      39.580 μs (0.00% GC)
+median time:      37.194 μs (0.00% GC)
 
-mean time:        55.564 μs (4.73% GC)
+mean time:        40.834 μs (6.25% GC)
 
-maximum time:     7.011 ms (96.27% GC)
+maximum time:     3.928 ms (98.31% GC)
 
 samples:          10000
 
@@ -1415,13 +1415,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.370 μs (0.00% GC)
+minimum time:     1.515 μs (0.00% GC)
 
-median time:      1.562 μs (0.00% GC)
+median time:      1.532 μs (0.00% GC)
 
-mean time:        1.954 μs (0.00% GC)
+mean time:        1.589 μs (0.00% GC)
 
-maximum time:     66.516 μs (0.00% GC)
+maximum time:     5.011 μs (0.00% GC)
 
 samples:          10000
 
@@ -1433,13 +1433,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.250 ns (0.00% GC)
+minimum time:     1.823 ns (0.00% GC)
 
-median time:      3.442 ns (0.00% GC)
+median time:      1.879 ns (0.00% GC)
 
-mean time:        3.403 ns (0.00% GC)
+mean time:        1.892 ns (0.00% GC)
 
-maximum time:     36.033 ns (0.00% GC)
+maximum time:     33.734 ns (0.00% GC)
 
 samples:          10000
 
@@ -1451,13 +1451,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      3.221 ns (0.00% GC)
+median time:      1.849 ns (0.00% GC)
 
-mean time:        3.273 ns (0.00% GC)
+mean time:        1.880 ns (0.00% GC)
 
-maximum time:     199.165 ns (0.00% GC)
+maximum time:     34.530 ns (0.00% GC)
 
 samples:          10000
 
@@ -1469,13 +1469,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.896 ns (0.00% GC)
+minimum time:     1.834 ns (0.00% GC)
 
-median time:      2.335 ns (0.00% GC)
+median time:      1.898 ns (0.00% GC)
 
-mean time:        3.066 ns (0.00% GC)
+mean time:        1.920 ns (0.00% GC)
 
-maximum time:     169.301 ns (0.00% GC)
+maximum time:     34.617 ns (0.00% GC)
 
 samples:          10000
 
@@ -1487,13 +1487,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.546 ns (0.00% GC)
+minimum time:     12.322 ns (0.00% GC)
 
-median time:      15.249 ns (0.00% GC)
+median time:      13.041 ns (0.00% GC)
 
-mean time:        19.139 ns (0.00% GC)
+mean time:        13.502 ns (0.00% GC)
 
-maximum time:     181.686 ns (0.00% GC)
+maximum time:     506.378 ns (0.00% GC)
 
 samples:          10000
 
@@ -1505,13 +1505,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.836 ns (0.00% GC)
+minimum time:     12.594 ns (0.00% GC)
 
-median time:      14.460 ns (0.00% GC)
+median time:      13.056 ns (0.00% GC)
 
-mean time:        18.367 ns (0.00% GC)
+mean time:        13.679 ns (0.00% GC)
 
-maximum time:     75.498 ns (0.00% GC)
+maximum time:     54.416 ns (0.00% GC)
 
 samples:          10000
 
@@ -1523,13 +1523,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.771 ns (0.00% GC)
+minimum time:     12.376 ns (0.00% GC)
 
-median time:      15.762 ns (0.00% GC)
+median time:      12.512 ns (0.00% GC)
 
-mean time:        19.794 ns (0.00% GC)
+mean time:        12.994 ns (0.00% GC)
 
-maximum time:     364.068 ns (0.00% GC)
+maximum time:     48.261 ns (0.00% GC)
 
 samples:          10000
 
@@ -1541,13 +1541,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.067 ns (0.00% GC)
+minimum time:     12.960 ns (0.00% GC)
 
-median time:      14.601 ns (0.00% GC)
+median time:      13.586 ns (0.00% GC)
 
-mean time:        18.343 ns (0.00% GC)
+mean time:        14.128 ns (0.00% GC)
 
-maximum time:     98.403 ns (0.00% GC)
+maximum time:     47.866 ns (0.00% GC)
 
 samples:          10000
 
@@ -1557,19 +1557,19 @@ evals/sample:     998
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  2.64 MiB
+memory estimate:  2.72 MiB
 
-allocs estimate:  76394
+allocs estimate:  81926
 
-minimum time:     21.292 ms (0.00% GC)
+minimum time:     15.795 ms (0.00% GC)
 
-median time:      25.783 ms (0.00% GC)
+median time:      16.132 ms (0.00% GC)
 
-mean time:        26.881 ms (2.42% GC)
+mean time:        16.513 ms (1.98% GC)
 
-maximum time:     44.801 ms (30.36% GC)
+maximum time:     22.112 ms (25.21% GC)
 
-samples:          186
+samples:          303
 
 evals/sample:     1
 
@@ -1579,13 +1579,13 @@ memory estimate:  384 bytes
 
 allocs estimate:  8
 
-minimum time:     1.378 μs (0.00% GC)
+minimum time:     1.290 μs (0.00% GC)
 
-median time:      2.220 μs (0.00% GC)
+median time:      1.526 μs (0.00% GC)
 
-mean time:        2.661 μs (0.00% GC)
+mean time:        1.534 μs (0.00% GC)
 
-maximum time:     52.404 μs (0.00% GC)
+maximum time:     52.241 μs (0.00% GC)
 
 samples:          10000
 
@@ -1597,17 +1597,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     428.379 ns (0.00% GC)
+minimum time:     335.493 ns (0.00% GC)
 
-median time:      558.040 ns (0.00% GC)
+median time:      360.915 ns (0.00% GC)
 
-mean time:        634.759 ns (0.00% GC)
+mean time:        363.952 ns (0.00% GC)
 
-maximum time:     3.750 μs (0.00% GC)
+maximum time:     789.585 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     198
+evals/sample:     217
 
 #### RLBase.state(env)
 
@@ -1615,17 +1615,17 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     945.696 ns (0.00% GC)
+minimum time:     1.060 μs (0.00% GC)
 
-median time:      1.183 μs (0.00% GC)
+median time:      1.085 μs (0.00% GC)
 
-mean time:        1.480 μs (2.69% GC)
+mean time:        1.130 μs (0.00% GC)
 
-maximum time:     399.850 μs (99.49% GC)
+maximum time:     4.844 μs (0.00% GC)
 
 samples:          10000
 
-evals/sample:     23
+evals/sample:     10
 
 #### RLBase.action_space(env)
 
@@ -1633,13 +1633,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.623 ns (0.00% GC)
+minimum time:     2.441 ns (0.00% GC)
 
-median time:      3.979 ns (0.00% GC)
+median time:      2.541 ns (0.00% GC)
 
-mean time:        4.175 ns (0.00% GC)
+mean time:        2.590 ns (0.00% GC)
 
-maximum time:     64.911 ns (0.00% GC)
+maximum time:     35.545 ns (0.00% GC)
 
 samples:          10000
 
@@ -1651,13 +1651,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.819 ns (0.00% GC)
 
-median time:      2.485 ns (0.00% GC)
+median time:      1.853 ns (0.00% GC)
 
-mean time:        2.635 ns (0.00% GC)
+mean time:        1.882 ns (0.00% GC)
 
-maximum time:     96.914 ns (0.00% GC)
+maximum time:     34.600 ns (0.00% GC)
 
 samples:          10000
 
@@ -1669,13 +1669,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.880 ns (0.00% GC)
+minimum time:     1.817 ns (0.00% GC)
 
-median time:      2.319 ns (0.00% GC)
+median time:      1.847 ns (0.00% GC)
 
-mean time:        2.474 ns (0.00% GC)
+mean time:        1.871 ns (0.00% GC)
 
-maximum time:     56.908 ns (0.00% GC)
+maximum time:     5.303 ns (0.00% GC)
 
 samples:          10000
 
@@ -1687,35 +1687,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     49.870 ns (0.00% GC)
+minimum time:     61.740 ns (0.00% GC)
 
-median time:      57.611 ns (0.00% GC)
+median time:      63.899 ns (0.00% GC)
 
-mean time:        77.079 ns (0.00% GC)
+mean time:        64.564 ns (0.00% GC)
 
-maximum time:     887.279 ns (0.00% GC)
+maximum time:     159.579 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     986
+evals/sample:     976
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  80 bytes
 
-allocs estimate:  2
+allocs estimate:  3
 
-minimum time:     47.315 ns (0.00% GC)
+minimum time:     68.726 ns (0.00% GC)
 
-median time:      74.793 ns (0.00% GC)
+median time:      70.040 ns (0.00% GC)
 
-mean time:        89.261 ns (8.69% GC)
+mean time:        77.741 ns (6.65% GC)
 
-maximum time:     8.275 μs (99.15% GC)
+maximum time:     3.642 μs (97.73% GC)
 
 samples:          10000
 
-evals/sample:     984
+evals/sample:     968
 
 #### env(GridWorlds.TurnLeft())
 
@@ -1723,17 +1723,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     49.593 ns (0.00% GC)
+minimum time:     62.037 ns (0.00% GC)
 
-median time:      59.050 ns (0.00% GC)
+median time:      63.726 ns (0.00% GC)
 
-mean time:        74.939 ns (0.00% GC)
+mean time:        64.357 ns (0.00% GC)
 
-maximum time:     264.292 ns (0.00% GC)
+maximum time:     119.404 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     986
+evals/sample:     976
 
 # GoToTargetUndirected
 
@@ -1743,15 +1743,15 @@ memory estimate:  1.68 MiB
 
 allocs estimate:  40008
 
-minimum time:     22.119 ms (0.00% GC)
+minimum time:     16.344 ms (0.00% GC)
 
-median time:      26.193 ms (0.00% GC)
+median time:      16.617 ms (0.00% GC)
 
-mean time:        27.039 ms (1.25% GC)
+mean time:        16.856 ms (1.09% GC)
 
-maximum time:     47.600 ms (21.99% GC)
+maximum time:     21.871 ms (22.96% GC)
 
-samples:          185
+samples:          297
 
 evals/sample:     1
 
@@ -1761,13 +1761,13 @@ memory estimate:  368 bytes
 
 allocs estimate:  8
 
-minimum time:     1.331 μs (0.00% GC)
+minimum time:     1.252 μs (0.00% GC)
 
-median time:      1.815 μs (0.00% GC)
+median time:      1.448 μs (0.00% GC)
 
-mean time:        2.351 μs (0.00% GC)
+mean time:        1.461 μs (0.00% GC)
 
-maximum time:     19.977 μs (0.00% GC)
+maximum time:     6.176 μs (0.00% GC)
 
 samples:          10000
 
@@ -1779,17 +1779,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     356.698 ns (0.00% GC)
+minimum time:     266.697 ns (0.00% GC)
 
-median time:      445.922 ns (0.00% GC)
+median time:      291.788 ns (0.00% GC)
 
-mean time:        510.907 ns (0.00% GC)
+mean time:        293.693 ns (0.00% GC)
 
-maximum time:     1.902 μs (0.00% GC)
+maximum time:     484.817 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     205
+evals/sample:     290
 
 #### RLBase.state(env)
 
@@ -1797,13 +1797,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.488 μs (0.00% GC)
+minimum time:     1.310 μs (0.00% GC)
 
-median time:      1.774 μs (0.00% GC)
+median time:      1.347 μs (0.00% GC)
 
-mean time:        2.151 μs (0.00% GC)
+mean time:        1.396 μs (0.00% GC)
 
-maximum time:     8.600 μs (0.00% GC)
+maximum time:     4.706 μs (0.00% GC)
 
 samples:          10000
 
@@ -1815,13 +1815,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.624 ns (0.00% GC)
+minimum time:     2.442 ns (0.00% GC)
 
-median time:      3.559 ns (0.00% GC)
+median time:      2.540 ns (0.00% GC)
 
-mean time:        4.137 ns (0.00% GC)
+mean time:        2.591 ns (0.00% GC)
 
-maximum time:     61.547 ns (0.00% GC)
+maximum time:     15.712 ns (0.00% GC)
 
 samples:          10000
 
@@ -1833,13 +1833,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.954 ns (0.00% GC)
+minimum time:     1.820 ns (0.00% GC)
 
-median time:      2.555 ns (0.00% GC)
+median time:      1.876 ns (0.00% GC)
 
-mean time:        2.690 ns (0.00% GC)
+mean time:        1.890 ns (0.00% GC)
 
-maximum time:     28.219 ns (0.00% GC)
+maximum time:     14.996 ns (0.00% GC)
 
 samples:          10000
 
@@ -1851,13 +1851,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.953 ns (0.00% GC)
+minimum time:     1.817 ns (0.00% GC)
 
-median time:      2.431 ns (0.00% GC)
+median time:      1.828 ns (0.00% GC)
 
-mean time:        2.586 ns (0.00% GC)
+mean time:        1.873 ns (0.00% GC)
 
-maximum time:     20.454 ns (0.00% GC)
+maximum time:     20.184 ns (0.00% GC)
 
 samples:          10000
 
@@ -1869,13 +1869,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     14.350 ns (0.00% GC)
+minimum time:     13.375 ns (0.00% GC)
 
-median time:      15.274 ns (0.00% GC)
+median time:      13.880 ns (0.00% GC)
 
-mean time:        20.134 ns (0.00% GC)
+mean time:        14.338 ns (0.00% GC)
 
-maximum time:     990.022 ns (0.00% GC)
+maximum time:     47.707 ns (0.00% GC)
 
 samples:          10000
 
@@ -1887,13 +1887,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     15.649 ns (0.00% GC)
+minimum time:     13.547 ns (0.00% GC)
 
-median time:      23.638 ns (0.00% GC)
+median time:      14.068 ns (0.00% GC)
 
-mean time:        23.311 ns (0.00% GC)
+mean time:        14.514 ns (0.00% GC)
 
-maximum time:     99.913 ns (0.00% GC)
+maximum time:     50.532 ns (0.00% GC)
 
 samples:          10000
 
@@ -1905,17 +1905,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     14.714 ns (0.00% GC)
+minimum time:     14.385 ns (0.00% GC)
 
-median time:      15.794 ns (0.00% GC)
+median time:      14.680 ns (0.00% GC)
 
-mean time:        20.358 ns (0.00% GC)
+mean time:        15.215 ns (0.00% GC)
 
-maximum time:     82.704 ns (0.00% GC)
+maximum time:     48.743 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     997
+evals/sample:     998
 
 #### env(GridWorlds.MoveRight())
 
@@ -1923,35 +1923,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     15.049 ns (0.00% GC)
+minimum time:     16.211 ns (0.00% GC)
 
-median time:      19.764 ns (0.00% GC)
+median time:      16.498 ns (0.00% GC)
 
-mean time:        22.688 ns (0.00% GC)
+mean time:        17.090 ns (0.00% GC)
 
-maximum time:     384.934 ns (0.00% GC)
+maximum time:     50.708 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     998
+evals/sample:     997
 
 # DoorKeyDirected
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  2.60 MiB
+memory estimate:  2.70 MiB
 
-allocs estimate:  74894
+allocs estimate:  81721
 
-minimum time:     20.190 ms (0.00% GC)
+minimum time:     16.007 ms (0.00% GC)
 
-median time:      22.978 ms (0.00% GC)
+median time:      16.400 ms (0.00% GC)
 
-mean time:        23.960 ms (2.22% GC)
+mean time:        16.782 ms (2.01% GC)
 
-maximum time:     40.362 ms (20.76% GC)
+maximum time:     22.581 ms (25.37% GC)
 
-samples:          209
+samples:          298
 
 evals/sample:     1
 
@@ -1961,13 +1961,13 @@ memory estimate:  528 bytes
 
 allocs estimate:  8
 
-minimum time:     1.436 μs (0.00% GC)
+minimum time:     1.179 μs (0.00% GC)
 
-median time:      1.939 μs (0.00% GC)
+median time:      1.369 μs (0.00% GC)
 
-mean time:        2.722 μs (3.15% GC)
+mean time:        1.388 μs (0.00% GC)
 
-maximum time:     860.355 μs (99.65% GC)
+maximum time:     5.554 μs (0.00% GC)
 
 samples:          10000
 
@@ -1979,17 +1979,17 @@ memory estimate:  80 bytes
 
 allocs estimate:  1
 
-minimum time:     439.066 ns (0.00% GC)
+minimum time:     362.849 ns (0.00% GC)
 
-median time:      652.240 ns (0.00% GC)
+median time:      380.078 ns (0.00% GC)
 
-mean time:        713.787 ns (1.13% GC)
+mean time:        392.181 ns (1.04% GC)
 
-maximum time:     33.206 μs (97.56% GC)
+maximum time:     14.305 μs (96.78% GC)
 
 samples:          10000
 
-evals/sample:     198
+evals/sample:     205
 
 #### RLBase.state(env)
 
@@ -1997,17 +1997,17 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     1.393 μs (0.00% GC)
+minimum time:     676.301 ns (0.00% GC)
 
-median time:      1.765 μs (0.00% GC)
+median time:      685.069 ns (0.00% GC)
 
-mean time:        2.055 μs (0.00% GC)
+mean time:        720.692 ns (3.56% GC)
 
-maximum time:     10.158 μs (0.00% GC)
+maximum time:     37.972 μs (97.97% GC)
 
 samples:          10000
 
-evals/sample:     10
+evals/sample:     153
 
 #### RLBase.action_space(env)
 
@@ -2015,13 +2015,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     1.823 ns (0.00% GC)
 
-median time:      2.293 ns (0.00% GC)
+median time:      1.857 ns (0.00% GC)
 
-mean time:        2.648 ns (0.00% GC)
+mean time:        1.886 ns (0.00% GC)
 
-maximum time:     20.918 ns (0.00% GC)
+maximum time:     33.921 ns (0.00% GC)
 
 samples:          10000
 
@@ -2033,13 +2033,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.248 ns (0.00% GC)
+minimum time:     1.819 ns (0.00% GC)
 
-median time:      2.816 ns (0.00% GC)
+median time:      1.867 ns (0.00% GC)
 
-mean time:        2.928 ns (0.00% GC)
+mean time:        1.890 ns (0.00% GC)
 
-maximum time:     29.378 ns (0.00% GC)
+maximum time:     14.950 ns (0.00% GC)
 
 samples:          10000
 
@@ -2051,13 +2051,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.897 ns (0.00% GC)
+minimum time:     1.815 ns (0.00% GC)
 
-median time:      4.412 ns (0.00% GC)
+median time:      1.835 ns (0.00% GC)
 
-mean time:        4.939 ns (0.00% GC)
+mean time:        1.869 ns (0.00% GC)
 
-maximum time:     627.964 ns (0.00% GC)
+maximum time:     33.392 ns (0.00% GC)
 
 samples:          10000
 
@@ -2069,17 +2069,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     50.872 ns (0.00% GC)
+minimum time:     60.894 ns (0.00% GC)
 
-median time:      83.221 ns (0.00% GC)
+median time:      62.512 ns (0.00% GC)
 
-mean time:        81.881 ns (0.00% GC)
+mean time:        63.201 ns (0.00% GC)
 
-maximum time:     2.737 μs (0.00% GC)
+maximum time:     130.980 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     987
+evals/sample:     976
 
 #### env(GridWorlds.PickUp())
 
@@ -2087,13 +2087,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.903 ns (0.00% GC)
+minimum time:     12.291 ns (0.00% GC)
 
-median time:      15.048 ns (0.00% GC)
+median time:      13.050 ns (0.00% GC)
 
-mean time:        19.407 ns (0.00% GC)
+mean time:        13.487 ns (0.00% GC)
 
-maximum time:     85.790 ns (0.00% GC)
+maximum time:     32.973 ns (0.00% GC)
 
 samples:          10000
 
@@ -2101,21 +2101,21 @@ evals/sample:     998
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  112 bytes
 
-allocs estimate:  2
+allocs estimate:  5
 
-minimum time:     50.302 ns (0.00% GC)
+minimum time:     108.999 ns (0.00% GC)
 
-median time:      78.794 ns (0.00% GC)
+median time:      111.559 ns (0.00% GC)
 
-mean time:        91.472 ns (9.21% GC)
+mean time:        121.687 ns (6.15% GC)
 
-maximum time:     8.166 μs (98.85% GC)
+maximum time:     3.938 μs (95.98% GC)
 
 samples:          10000
 
-evals/sample:     984
+evals/sample:     921
 
 #### env(GridWorlds.TurnLeft())
 
@@ -2123,17 +2123,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     50.766 ns (0.00% GC)
+minimum time:     60.153 ns (0.00% GC)
 
-median time:      62.908 ns (0.00% GC)
+median time:      62.397 ns (0.00% GC)
 
-mean time:        75.318 ns (0.00% GC)
+mean time:        63.176 ns (0.00% GC)
 
-maximum time:     191.966 ns (0.00% GC)
+maximum time:     136.778 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     987
+evals/sample:     978
 
 # DoorKeyUndirected
 
@@ -2143,15 +2143,15 @@ memory estimate:  1.69 MiB
 
 allocs estimate:  40108
 
-minimum time:     24.312 ms (0.00% GC)
+minimum time:     17.397 ms (0.00% GC)
 
-median time:      28.160 ms (0.00% GC)
+median time:      17.726 ms (0.00% GC)
 
-mean time:        28.764 ms (1.15% GC)
+mean time:        18.763 ms (1.02% GC)
 
-maximum time:     47.078 ms (25.87% GC)
+maximum time:     39.427 ms (0.00% GC)
 
-samples:          174
+samples:          267
 
 evals/sample:     1
 
@@ -2161,13 +2161,13 @@ memory estimate:  512 bytes
 
 allocs estimate:  8
 
-minimum time:     1.360 μs (0.00% GC)
+minimum time:     1.234 μs (0.00% GC)
 
-median time:      1.771 μs (0.00% GC)
+median time:      1.472 μs (0.00% GC)
 
-mean time:        2.341 μs (3.96% GC)
+mean time:        1.560 μs (2.91% GC)
 
-maximum time:     933.003 μs (99.44% GC)
+maximum time:     456.738 μs (99.40% GC)
 
 samples:          10000
 
@@ -2179,17 +2179,17 @@ memory estimate:  80 bytes
 
 allocs estimate:  1
 
-minimum time:     353.176 ns (0.00% GC)
+minimum time:     305.963 ns (0.00% GC)
 
-median time:      674.407 ns (0.00% GC)
+median time:      322.827 ns (0.00% GC)
 
-mean time:        667.685 ns (1.25% GC)
+mean time:        335.244 ns (1.13% GC)
 
-maximum time:     40.074 μs (97.99% GC)
+maximum time:     13.418 μs (97.10% GC)
 
 samples:          10000
 
-evals/sample:     205
+evals/sample:     217
 
 #### RLBase.state(env)
 
@@ -2197,13 +2197,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.198 μs (0.00% GC)
+minimum time:     1.170 μs (0.00% GC)
 
-median time:      1.339 μs (0.00% GC)
+median time:      1.237 μs (0.00% GC)
 
-mean time:        1.364 μs (0.00% GC)
+mean time:        1.289 μs (0.00% GC)
 
-maximum time:     6.369 μs (0.00% GC)
+maximum time:     9.201 μs (0.00% GC)
 
 samples:          10000
 
@@ -2215,13 +2215,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.530 ns (0.00% GC)
+minimum time:     2.528 ns (0.00% GC)
 
-median time:      2.633 ns (0.00% GC)
+median time:      2.549 ns (0.00% GC)
 
-mean time:        2.801 ns (0.00% GC)
+mean time:        2.608 ns (0.00% GC)
 
-maximum time:     54.819 ns (0.00% GC)
+maximum time:     34.217 ns (0.00% GC)
 
 samples:          10000
 
@@ -2233,13 +2233,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.954 ns (0.00% GC)
+minimum time:     1.820 ns (0.00% GC)
 
-median time:      2.809 ns (0.00% GC)
+median time:      1.890 ns (0.00% GC)
 
-mean time:        2.851 ns (0.00% GC)
+mean time:        1.890 ns (0.00% GC)
 
-maximum time:     34.719 ns (0.00% GC)
+maximum time:     33.507 ns (0.00% GC)
 
 samples:          10000
 
@@ -2251,13 +2251,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.880 ns (0.00% GC)
+minimum time:     12.838 ns (0.00% GC)
 
-median time:      2.503 ns (0.00% GC)
+median time:      12.976 ns (0.00% GC)
 
-mean time:        2.536 ns (0.00% GC)
+mean time:        13.407 ns (0.00% GC)
 
-maximum time:     26.564 ns (0.00% GC)
+maximum time:     143.646 ns (0.00% GC)
 
 samples:          10000
 
@@ -2269,13 +2269,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.652 ns (0.00% GC)
+minimum time:     14.018 ns (0.00% GC)
 
-median time:      14.981 ns (0.00% GC)
+median time:      14.467 ns (0.00% GC)
 
-mean time:        18.018 ns (0.00% GC)
+mean time:        15.040 ns (0.00% GC)
 
-maximum time:     76.921 ns (0.00% GC)
+maximum time:     49.553 ns (0.00% GC)
 
 samples:          10000
 
@@ -2287,13 +2287,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     14.228 ns (0.00% GC)
+minimum time:     14.118 ns (0.00% GC)
 
-median time:      15.315 ns (0.00% GC)
+median time:      14.763 ns (0.00% GC)
 
-mean time:        18.669 ns (0.00% GC)
+mean time:        15.232 ns (0.00% GC)
 
-maximum time:     70.291 ns (0.00% GC)
+maximum time:     55.378 ns (0.00% GC)
 
 samples:          10000
 
@@ -2305,13 +2305,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     14.649 ns (0.00% GC)
+minimum time:     13.759 ns (0.00% GC)
 
-median time:      15.668 ns (0.00% GC)
+median time:      14.201 ns (0.00% GC)
 
-mean time:        19.389 ns (0.00% GC)
+mean time:        14.669 ns (0.00% GC)
 
-maximum time:     67.772 ns (0.00% GC)
+maximum time:     47.832 ns (0.00% GC)
 
 samples:          10000
 
@@ -2323,13 +2323,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.792 ns (0.00% GC)
+minimum time:     14.405 ns (0.00% GC)
 
-median time:      15.489 ns (0.00% GC)
+median time:      15.192 ns (0.00% GC)
 
-mean time:        19.302 ns (0.00% GC)
+mean time:        15.635 ns (0.00% GC)
 
-maximum time:     67.336 ns (0.00% GC)
+maximum time:     36.321 ns (0.00% GC)
 
 samples:          10000
 
@@ -2341,13 +2341,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.578 ns (0.00% GC)
+minimum time:     11.756 ns (0.00% GC)
 
-median time:      14.897 ns (0.00% GC)
+median time:      13.012 ns (0.00% GC)
 
-mean time:        19.347 ns (0.00% GC)
+mean time:        13.505 ns (0.00% GC)
 
-maximum time:     58.612 ns (0.00% GC)
+maximum time:     46.782 ns (0.00% GC)
 
 samples:          10000
 
@@ -2357,19 +2357,19 @@ evals/sample:     998
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  2.65 MiB
+memory estimate:  2.73 MiB
 
-allocs estimate:  76505
+allocs estimate:  81982
 
-minimum time:     19.100 ms (0.00% GC)
+minimum time:     15.332 ms (0.00% GC)
 
-median time:      21.787 ms (0.00% GC)
+median time:      15.629 ms (0.00% GC)
 
-mean time:        22.847 ms (2.72% GC)
+mean time:        16.043 ms (2.14% GC)
 
-maximum time:     39.644 ms (32.28% GC)
+maximum time:     22.552 ms (25.33% GC)
 
-samples:          219
+samples:          312
 
 evals/sample:     1
 
@@ -2379,17 +2379,17 @@ memory estimate:  688 bytes
 
 allocs estimate:  9
 
-minimum time:     2.219 μs (0.00% GC)
+minimum time:     1.744 μs (0.00% GC)
 
-median time:      4.060 μs (0.00% GC)
+median time:      2.123 μs (0.00% GC)
 
-mean time:        4.476 μs (2.66% GC)
+mean time:        2.231 μs (2.67% GC)
 
-maximum time:     1.202 ms (99.28% GC)
+maximum time:     599.704 μs (99.34% GC)
 
 samples:          10000
 
-evals/sample:     9
+evals/sample:     10
 
 #### RLBase.reset!(env)
 
@@ -2397,13 +2397,13 @@ memory estimate:  96 bytes
 
 allocs estimate:  1
 
-minimum time:     1.131 μs (0.00% GC)
+minimum time:     815.000 ns (0.00% GC)
 
-median time:      1.956 μs (0.00% GC)
+median time:      1.103 μs (0.00% GC)
 
-mean time:        2.002 μs (0.00% GC)
+mean time:        1.123 μs (0.00% GC)
 
-maximum time:     13.877 μs (0.00% GC)
+maximum time:     4.680 μs (0.00% GC)
 
 samples:          10000
 
@@ -2415,13 +2415,13 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     1.129 μs (0.00% GC)
+minimum time:     1.285 μs (0.00% GC)
 
-median time:      1.715 μs (0.00% GC)
+median time:      1.326 μs (0.00% GC)
 
-mean time:        1.808 μs (0.00% GC)
+mean time:        1.373 μs (0.00% GC)
 
-maximum time:     7.706 μs (0.00% GC)
+maximum time:     4.702 μs (0.00% GC)
 
 samples:          10000
 
@@ -2433,13 +2433,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.630 ns (0.00% GC)
+minimum time:     2.442 ns (0.00% GC)
 
-median time:      3.592 ns (0.00% GC)
+median time:      2.549 ns (0.00% GC)
 
-mean time:        3.724 ns (0.00% GC)
+mean time:        2.731 ns (0.00% GC)
 
-maximum time:     291.876 ns (0.00% GC)
+maximum time:     622.419 ns (0.00% GC)
 
 samples:          10000
 
@@ -2451,13 +2451,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.883 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      2.123 ns (0.00% GC)
+median time:      1.870 ns (0.00% GC)
 
-mean time:        2.875 ns (0.00% GC)
+mean time:        1.893 ns (0.00% GC)
 
-maximum time:     27.392 ns (0.00% GC)
+maximum time:     33.391 ns (0.00% GC)
 
 samples:          10000
 
@@ -2469,13 +2469,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.896 ns (0.00% GC)
+minimum time:     1.816 ns (0.00% GC)
 
-median time:      2.137 ns (0.00% GC)
+median time:      1.833 ns (0.00% GC)
 
-mean time:        2.634 ns (0.00% GC)
+mean time:        1.862 ns (0.00% GC)
 
-maximum time:     25.880 ns (0.00% GC)
+maximum time:     15.446 ns (0.00% GC)
 
 samples:          10000
 
@@ -2487,35 +2487,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     44.297 ns (0.00% GC)
+minimum time:     58.073 ns (0.00% GC)
 
-median time:      49.029 ns (0.00% GC)
+median time:      59.365 ns (0.00% GC)
 
-mean time:        58.975 ns (0.00% GC)
+mean time:        60.398 ns (0.00% GC)
 
-maximum time:     184.127 ns (0.00% GC)
+maximum time:     728.450 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     988
+evals/sample:     979
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  80 bytes
 
-allocs estimate:  2
+allocs estimate:  3
 
-minimum time:     45.264 ns (0.00% GC)
+minimum time:     70.263 ns (0.00% GC)
 
-median time:      48.317 ns (0.00% GC)
+median time:      72.389 ns (0.00% GC)
 
-mean time:        67.853 ns (9.07% GC)
+mean time:        80.076 ns (6.51% GC)
 
-maximum time:     7.047 μs (99.02% GC)
+maximum time:     3.723 μs (97.28% GC)
 
 samples:          10000
 
-evals/sample:     987
+evals/sample:     967
 
 #### env(GridWorlds.TurnLeft())
 
@@ -2523,17 +2523,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     44.174 ns (0.00% GC)
+minimum time:     58.109 ns (0.00% GC)
 
-median time:      49.296 ns (0.00% GC)
+median time:      60.231 ns (0.00% GC)
 
-mean time:        61.281 ns (0.00% GC)
+mean time:        61.302 ns (0.00% GC)
 
-maximum time:     198.916 ns (0.00% GC)
+maximum time:     182.148 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     988
+evals/sample:     979
 
 # CollectGemsUndirected
 
@@ -2543,15 +2543,15 @@ memory estimate:  1.69 MiB
 
 allocs estimate:  40109
 
-minimum time:     19.916 ms (0.00% GC)
+minimum time:     15.567 ms (0.00% GC)
 
-median time:      23.042 ms (0.00% GC)
+median time:      15.723 ms (0.00% GC)
 
-mean time:        23.578 ms (1.42% GC)
+mean time:        15.989 ms (1.20% GC)
 
-maximum time:     33.668 ms (33.88% GC)
+maximum time:     21.531 ms (23.36% GC)
 
-samples:          213
+samples:          313
 
 evals/sample:     1
 
@@ -2561,17 +2561,17 @@ memory estimate:  688 bytes
 
 allocs estimate:  9
 
-minimum time:     2.121 μs (0.00% GC)
+minimum time:     1.692 μs (0.00% GC)
 
-median time:      2.824 μs (0.00% GC)
+median time:      2.025 μs (0.00% GC)
 
-mean time:        3.547 μs (1.90% GC)
+mean time:        2.110 μs (2.84% GC)
 
-maximum time:     679.643 μs (99.16% GC)
+maximum time:     601.859 μs (99.41% GC)
 
 samples:          10000
 
-evals/sample:     9
+evals/sample:     10
 
 #### RLBase.reset!(env)
 
@@ -2579,17 +2579,17 @@ memory estimate:  96 bytes
 
 allocs estimate:  1
 
-minimum time:     943.900 ns (0.00% GC)
+minimum time:     827.393 ns (0.00% GC)
 
-median time:      1.394 μs (0.00% GC)
+median time:      1.016 μs (0.00% GC)
 
-mean time:        1.564 μs (0.00% GC)
+mean time:        1.023 μs (0.00% GC)
 
-maximum time:     6.605 μs (0.00% GC)
+maximum time:     2.602 μs (0.00% GC)
 
 samples:          10000
 
-evals/sample:     10
+evals/sample:     28
 
 #### RLBase.state(env)
 
@@ -2597,13 +2597,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.367 μs (0.00% GC)
+minimum time:     1.027 μs (0.00% GC)
 
-median time:      1.733 μs (0.00% GC)
+median time:      1.065 μs (0.00% GC)
 
-mean time:        2.062 μs (0.00% GC)
+mean time:        1.105 μs (0.00% GC)
 
-maximum time:     5.984 μs (0.00% GC)
+maximum time:     3.552 μs (0.00% GC)
 
 samples:          10000
 
@@ -2615,13 +2615,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.621 ns (0.00% GC)
+minimum time:     1.823 ns (0.00% GC)
 
-median time:      2.964 ns (0.00% GC)
+median time:      1.900 ns (0.00% GC)
 
-mean time:        3.772 ns (0.00% GC)
+mean time:        1.954 ns (0.00% GC)
 
-maximum time:     35.471 ns (0.00% GC)
+maximum time:     33.570 ns (0.00% GC)
 
 samples:          10000
 
@@ -2633,13 +2633,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      2.663 ns (0.00% GC)
+median time:      1.853 ns (0.00% GC)
 
-mean time:        2.674 ns (0.00% GC)
+mean time:        1.886 ns (0.00% GC)
 
-maximum time:     32.410 ns (0.00% GC)
+maximum time:     33.925 ns (0.00% GC)
 
 samples:          10000
 
@@ -2651,13 +2651,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.885 ns (0.00% GC)
+minimum time:     1.832 ns (0.00% GC)
 
-median time:      2.458 ns (0.00% GC)
+median time:      1.892 ns (0.00% GC)
 
-mean time:        4.363 ns (0.00% GC)
+mean time:        1.903 ns (0.00% GC)
 
-maximum time:     6.719 μs (0.00% GC)
+maximum time:     33.689 ns (0.00% GC)
 
 samples:          10000
 
@@ -2669,13 +2669,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     14.332 ns (0.00% GC)
+minimum time:     13.081 ns (0.00% GC)
 
-median time:      15.237 ns (0.00% GC)
+median time:      13.675 ns (0.00% GC)
 
-mean time:        18.025 ns (0.00% GC)
+mean time:        14.145 ns (0.00% GC)
 
-maximum time:     92.872 ns (0.00% GC)
+maximum time:     47.493 ns (0.00% GC)
 
 samples:          10000
 
@@ -2687,13 +2687,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     13.620 ns (0.00% GC)
+minimum time:     13.044 ns (0.00% GC)
 
-median time:      14.580 ns (0.00% GC)
+median time:      13.558 ns (0.00% GC)
 
-mean time:        18.303 ns (0.00% GC)
+mean time:        14.031 ns (0.00% GC)
 
-maximum time:     78.764 ns (0.00% GC)
+maximum time:     47.584 ns (0.00% GC)
 
 samples:          10000
 
@@ -2705,13 +2705,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     14.001 ns (0.00% GC)
+minimum time:     14.324 ns (0.00% GC)
 
-median time:      15.675 ns (0.00% GC)
+median time:      15.045 ns (0.00% GC)
 
-mean time:        19.826 ns (0.00% GC)
+mean time:        15.485 ns (0.00% GC)
 
-maximum time:     344.320 ns (0.00% GC)
+maximum time:     49.043 ns (0.00% GC)
 
 samples:          10000
 
@@ -2723,35 +2723,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     15.435 ns (0.00% GC)
+minimum time:     14.164 ns (0.00% GC)
 
-median time:      16.710 ns (0.00% GC)
+median time:      15.063 ns (0.00% GC)
 
-mean time:        20.612 ns (0.00% GC)
+mean time:        15.420 ns (0.00% GC)
 
-maximum time:     115.984 ns (0.00% GC)
+maximum time:     48.870 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     997
+evals/sample:     998
 
 # DynamicObstaclesDirected
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  13.34 MiB
+memory estimate:  13.41 MiB
 
-allocs estimate:  154914
+allocs estimate:  159099
 
-minimum time:     43.464 ms (0.00% GC)
+minimum time:     31.035 ms (0.00% GC)
 
-median time:      49.704 ms (0.00% GC)
+median time:      31.867 ms (0.00% GC)
 
-mean time:        50.867 ms (4.45% GC)
+mean time:        33.336 ms (3.62% GC)
 
-maximum time:     69.528 ms (12.23% GC)
+maximum time:     40.869 ms (0.00% GC)
 
-samples:          99
+samples:          150
 
 evals/sample:     1
 
@@ -2761,17 +2761,17 @@ memory estimate:  592 bytes
 
 allocs estimate:  10
 
-minimum time:     1.933 μs (0.00% GC)
+minimum time:     1.508 μs (0.00% GC)
 
-median time:      2.703 μs (0.00% GC)
+median time:      1.829 μs (0.00% GC)
 
-mean time:        3.458 μs (1.56% GC)
+mean time:        1.928 μs (2.56% GC)
 
-maximum time:     543.803 μs (99.08% GC)
+maximum time:     497.458 μs (99.30% GC)
 
 samples:          10000
 
-evals/sample:     9
+evals/sample:     10
 
 #### RLBase.reset!(env)
 
@@ -2779,17 +2779,17 @@ memory estimate:  160 bytes
 
 allocs estimate:  2
 
-minimum time:     798.960 ns (0.00% GC)
+minimum time:     663.127 ns (0.00% GC)
 
-median time:      1.080 μs (0.00% GC)
+median time:      727.430 ns (0.00% GC)
 
-mean time:        1.254 μs (0.53% GC)
+mean time:        768.607 ns (1.02% GC)
 
-maximum time:     67.581 μs (98.08% GC)
+maximum time:     21.184 μs (96.22% GC)
 
 samples:          10000
 
-evals/sample:     50
+evals/sample:     142
 
 #### RLBase.state(env)
 
@@ -2797,17 +2797,17 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     1.511 μs (0.00% GC)
+minimum time:     869.436 ns (0.00% GC)
 
-median time:      1.675 μs (0.00% GC)
+median time:      881.509 ns (0.00% GC)
 
-mean time:        2.041 μs (0.00% GC)
+mean time:        931.948 ns (2.29% GC)
 
-maximum time:     8.944 μs (0.00% GC)
+maximum time:     110.115 μs (99.02% GC)
 
 samples:          10000
 
-evals/sample:     10
+evals/sample:     55
 
 #### RLBase.action_space(env)
 
@@ -2815,13 +2815,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.883 ns (0.00% GC)
+minimum time:     2.443 ns (0.00% GC)
 
-median time:      2.869 ns (0.00% GC)
+median time:      2.549 ns (0.00% GC)
 
-mean time:        3.189 ns (0.00% GC)
+mean time:        2.595 ns (0.00% GC)
 
-maximum time:     86.427 ns (0.00% GC)
+maximum time:     34.360 ns (0.00% GC)
 
 samples:          10000
 
@@ -2833,13 +2833,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.883 ns (0.00% GC)
+minimum time:     1.819 ns (0.00% GC)
 
-median time:      2.290 ns (0.00% GC)
+median time:      1.869 ns (0.00% GC)
 
-mean time:        2.995 ns (0.00% GC)
+mean time:        1.889 ns (0.00% GC)
 
-maximum time:     86.363 ns (0.00% GC)
+maximum time:     15.101 ns (0.00% GC)
 
 samples:          10000
 
@@ -2851,13 +2851,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.897 ns (0.00% GC)
+minimum time:     1.832 ns (0.00% GC)
 
-median time:      2.465 ns (0.00% GC)
+median time:      1.886 ns (0.00% GC)
 
-mean time:        3.032 ns (0.00% GC)
+mean time:        1.910 ns (0.00% GC)
 
-maximum time:     53.962 ns (0.00% GC)
+maximum time:     33.665 ns (0.00% GC)
 
 samples:          10000
 
@@ -2865,17 +2865,17 @@ evals/sample:     1000
 
 #### env(GridWorlds.TurnRight())
 
-memory estimate:  998 bytes
+memory estimate:  1.00 KiB
 
 allocs estimate:  8
 
-minimum time:     1.647 μs (0.00% GC)
+minimum time:     1.483 μs (0.00% GC)
 
-median time:      2.284 μs (0.00% GC)
+median time:      1.664 μs (0.00% GC)
 
-mean time:        2.740 μs (5.49% GC)
+mean time:        1.857 μs (3.68% GC)
 
-maximum time:     832.287 μs (99.40% GC)
+maximum time:     349.913 μs (99.11% GC)
 
 samples:          10000
 
@@ -2883,17 +2883,17 @@ evals/sample:     10
 
 #### env(GridWorlds.NoMove())
 
-memory estimate:  1.01 KiB
+memory estimate:  1008 bytes
 
 allocs estimate:  8
 
-minimum time:     1.616 μs (0.00% GC)
+minimum time:     1.408 μs (0.00% GC)
 
-median time:      2.257 μs (0.00% GC)
+median time:      1.587 μs (0.00% GC)
 
-mean time:        2.637 μs (4.09% GC)
+mean time:        1.776 μs (3.99% GC)
 
-maximum time:     647.351 μs (99.41% GC)
+maximum time:     370.339 μs (99.26% GC)
 
 samples:          10000
 
@@ -2901,17 +2901,17 @@ evals/sample:     10
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  1.08 KiB
+memory estimate:  1.07 KiB
 
-allocs estimate:  10
+allocs estimate:  11
 
-minimum time:     1.651 μs (0.00% GC)
+minimum time:     1.474 μs (0.00% GC)
 
-median time:      2.169 μs (0.00% GC)
+median time:      1.632 μs (0.00% GC)
 
-mean time:        2.602 μs (4.30% GC)
+mean time:        1.838 μs (4.20% GC)
 
-maximum time:     566.785 μs (98.94% GC)
+maximum time:     398.552 μs (99.29% GC)
 
 samples:          10000
 
@@ -2919,17 +2919,17 @@ evals/sample:     10
 
 #### env(GridWorlds.TurnLeft())
 
-memory estimate:  1.02 KiB
+memory estimate:  1017 bytes
 
 allocs estimate:  8
 
-minimum time:     1.664 μs (0.00% GC)
+minimum time:     1.487 μs (0.00% GC)
 
-median time:      2.144 μs (0.00% GC)
+median time:      1.673 μs (0.00% GC)
 
-mean time:        2.573 μs (5.75% GC)
+mean time:        1.861 μs (3.80% GC)
 
-maximum time:     749.633 μs (99.45% GC)
+maximum time:     358.381 μs (99.31% GC)
 
 samples:          10000
 
@@ -2943,15 +2943,15 @@ memory estimate:  12.43 MiB
 
 allocs estimate:  120210
 
-minimum time:     44.748 ms (0.00% GC)
+minimum time:     32.462 ms (0.00% GC)
 
-median time:      52.461 ms (0.00% GC)
+median time:      32.842 ms (0.00% GC)
 
-mean time:        53.528 ms (3.87% GC)
+mean time:        34.010 ms (2.92% GC)
 
-maximum time:     75.505 ms (13.13% GC)
+maximum time:     39.609 ms (9.17% GC)
 
-samples:          94
+samples:          147
 
 evals/sample:     1
 
@@ -2961,17 +2961,17 @@ memory estimate:  576 bytes
 
 allocs estimate:  10
 
-minimum time:     1.876 μs (0.00% GC)
+minimum time:     1.472 μs (0.00% GC)
 
-median time:      2.480 μs (0.00% GC)
+median time:      1.724 μs (0.00% GC)
 
-mean time:        3.215 μs (3.69% GC)
+mean time:        1.804 μs (2.97% GC)
 
-maximum time:     1.197 ms (99.05% GC)
+maximum time:     538.995 μs (99.38% GC)
 
 samples:          10000
 
-evals/sample:     9
+evals/sample:     10
 
 #### RLBase.reset!(env)
 
@@ -2979,17 +2979,17 @@ memory estimate:  160 bytes
 
 allocs estimate:  2
 
-minimum time:     743.886 ns (0.00% GC)
+minimum time:     592.877 ns (0.00% GC)
 
-median time:      938.773 ns (0.00% GC)
+median time:      646.058 ns (0.00% GC)
 
-mean time:        1.087 μs (1.51% GC)
+mean time:        665.940 ns (1.42% GC)
 
-maximum time:     64.532 μs (98.18% GC)
+maximum time:     17.285 μs (95.92% GC)
 
 samples:          10000
 
-evals/sample:     88
+evals/sample:     171
 
 #### RLBase.state(env)
 
@@ -2997,13 +2997,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.803 μs (0.00% GC)
+minimum time:     1.593 μs (0.00% GC)
 
-median time:      1.929 μs (0.00% GC)
+median time:      1.616 μs (0.00% GC)
 
-mean time:        2.349 μs (0.00% GC)
+mean time:        1.671 μs (0.00% GC)
 
-maximum time:     10.842 μs (0.00% GC)
+maximum time:     5.038 μs (0.00% GC)
 
 samples:          10000
 
@@ -3015,13 +3015,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.883 ns (0.00% GC)
+minimum time:     2.441 ns (0.00% GC)
 
-median time:      2.320 ns (0.00% GC)
+median time:      2.542 ns (0.00% GC)
 
-mean time:        2.672 ns (0.00% GC)
+mean time:        2.588 ns (0.00% GC)
 
-maximum time:     43.675 ns (0.00% GC)
+maximum time:     15.640 ns (0.00% GC)
 
 samples:          10000
 
@@ -3033,13 +3033,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      2.212 ns (0.00% GC)
+median time:      1.857 ns (0.00% GC)
 
-mean time:        2.493 ns (0.00% GC)
+mean time:        1.882 ns (0.00% GC)
 
-maximum time:     27.164 ns (0.00% GC)
+maximum time:     15.039 ns (0.00% GC)
 
 samples:          10000
 
@@ -3051,13 +3051,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.897 ns (0.00% GC)
+minimum time:     1.832 ns (0.00% GC)
 
-median time:      2.339 ns (0.00% GC)
+median time:      1.884 ns (0.00% GC)
 
-mean time:        2.900 ns (0.00% GC)
+mean time:        1.901 ns (0.00% GC)
 
-maximum time:     1.349 μs (0.00% GC)
+maximum time:     15.105 ns (0.00% GC)
 
 samples:          10000
 
@@ -3065,17 +3065,17 @@ evals/sample:     1000
 
 #### env(GridWorlds.MoveDown())
 
-memory estimate:  1.01 KiB
+memory estimate:  1.00 KiB
 
 allocs estimate:  8
 
-minimum time:     1.667 μs (0.00% GC)
+minimum time:     1.401 μs (0.00% GC)
 
-median time:      2.428 μs (0.00% GC)
+median time:      1.590 μs (0.00% GC)
 
-mean time:        2.951 μs (5.24% GC)
+mean time:        1.777 μs (3.99% GC)
 
-maximum time:     944.578 μs (99.66% GC)
+maximum time:     368.366 μs (99.19% GC)
 
 samples:          10000
 
@@ -3083,17 +3083,17 @@ evals/sample:     10
 
 #### env(GridWorlds.NoMove())
 
-memory estimate:  1019 bytes
+memory estimate:  1020 bytes
 
 allocs estimate:  8
 
-minimum time:     1.654 μs (0.00% GC)
+minimum time:     1.391 μs (0.00% GC)
 
-median time:      2.416 μs (0.00% GC)
+median time:      1.592 μs (0.00% GC)
 
-mean time:        2.793 μs (4.83% GC)
+mean time:        1.774 μs (4.00% GC)
 
-maximum time:     719.779 μs (99.39% GC)
+maximum time:     360.800 μs (99.35% GC)
 
 samples:          10000
 
@@ -3101,17 +3101,17 @@ evals/sample:     10
 
 #### env(GridWorlds.MoveUp())
 
-memory estimate:  1.00 KiB
+memory estimate:  1008 bytes
 
 allocs estimate:  8
 
-minimum time:     1.594 μs (0.00% GC)
+minimum time:     1.396 μs (0.00% GC)
 
-median time:      2.013 μs (0.00% GC)
+median time:      1.591 μs (0.00% GC)
 
-mean time:        2.528 μs (4.94% GC)
+mean time:        1.770 μs (4.12% GC)
 
-maximum time:     823.665 μs (99.48% GC)
+maximum time:     374.526 μs (99.31% GC)
 
 samples:          10000
 
@@ -3123,13 +3123,13 @@ memory estimate:  1.00 KiB
 
 allocs estimate:  8
 
-minimum time:     1.650 μs (0.00% GC)
+minimum time:     1.385 μs (0.00% GC)
 
-median time:      2.738 μs (0.00% GC)
+median time:      1.579 μs (0.00% GC)
 
-mean time:        3.010 μs (5.41% GC)
+mean time:        1.764 μs (4.00% GC)
 
-maximum time:     823.646 μs (99.59% GC)
+maximum time:     357.526 μs (99.40% GC)
 
 samples:          10000
 
@@ -3137,17 +3137,17 @@ evals/sample:     10
 
 #### env(GridWorlds.MoveRight())
 
-memory estimate:  1020 bytes
+memory estimate:  1009 bytes
 
 allocs estimate:  8
 
-minimum time:     1.638 μs (0.00% GC)
+minimum time:     1.400 μs (0.00% GC)
 
-median time:      2.140 μs (0.00% GC)
+median time:      1.601 μs (0.00% GC)
 
-mean time:        2.572 μs (5.75% GC)
+mean time:        1.784 μs (3.99% GC)
 
-maximum time:     760.465 μs (99.57% GC)
+maximum time:     367.036 μs (99.39% GC)
 
 samples:          10000
 
@@ -3157,37 +3157,37 @@ evals/sample:     10
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  3.45 MiB
+memory estimate:  3.48 MiB
 
-allocs estimate:  83327
+allocs estimate:  89657
 
-minimum time:     6.698 ms (0.00% GC)
+minimum time:     6.740 ms (0.00% GC)
 
-median time:      9.498 ms (0.00% GC)
+median time:      6.887 ms (0.00% GC)
 
-mean time:        10.004 ms (5.55% GC)
+mean time:        7.325 ms (4.79% GC)
 
-maximum time:     21.005 ms (47.99% GC)
+maximum time:     17.972 ms (36.81% GC)
 
-samples:          500
+samples:          682
 
 evals/sample:     1
 
 #### GridWorlds.SokobanDirected()
 
-memory estimate:  888.08 KiB
+memory estimate:  794.78 KiB
 
-allocs estimate:  24662
+allocs estimate:  23092
 
-minimum time:     1.454 ms (0.00% GC)
+minimum time:     1.737 ms (0.00% GC)
 
-median time:      1.980 ms (0.00% GC)
+median time:      1.767 ms (0.00% GC)
 
-mean time:        2.334 ms (6.25% GC)
+mean time:        1.854 ms (3.48% GC)
 
-maximum time:     13.849 ms (75.49% GC)
+maximum time:     6.063 ms (66.88% GC)
 
-samples:          2138
+samples:          2691
 
 evals/sample:     1
 
@@ -3197,17 +3197,17 @@ memory estimate:  480 bytes
 
 allocs estimate:  5
 
-minimum time:     1.888 μs (0.00% GC)
+minimum time:     2.334 μs (0.00% GC)
 
-median time:      2.194 μs (0.00% GC)
+median time:      2.600 μs (0.00% GC)
 
-mean time:        2.339 μs (1.58% GC)
+mean time:        2.669 μs (1.35% GC)
 
-maximum time:     372.559 μs (99.25% GC)
+maximum time:     363.905 μs (99.08% GC)
 
 samples:          10000
 
-evals/sample:     10
+evals/sample:     9
 
 #### RLBase.state(env)
 
@@ -3215,17 +3215,17 @@ memory estimate:  208 bytes
 
 allocs estimate:  3
 
-minimum time:     120.722 ns (0.00% GC)
+minimum time:     109.943 ns (0.00% GC)
 
-median time:      131.256 ns (0.00% GC)
+median time:      112.747 ns (0.00% GC)
 
-mean time:        168.377 ns (10.57% GC)
+mean time:        129.483 ns (10.43% GC)
 
-maximum time:     8.015 μs (96.31% GC)
+maximum time:     3.897 μs (95.60% GC)
 
 samples:          10000
 
-evals/sample:     864
+evals/sample:     914
 
 #### RLBase.action_space(env)
 
@@ -3233,13 +3233,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.249 ns (0.00% GC)
+minimum time:     2.174 ns (0.00% GC)
 
-median time:      2.260 ns (0.00% GC)
+median time:      2.200 ns (0.00% GC)
 
-mean time:        2.390 ns (0.00% GC)
+mean time:        2.247 ns (0.00% GC)
 
-maximum time:     34.074 ns (0.00% GC)
+maximum time:     34.398 ns (0.00% GC)
 
 samples:          10000
 
@@ -3251,13 +3251,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.883 ns (0.00% GC)
+minimum time:     1.817 ns (0.00% GC)
 
-median time:      1.893 ns (0.00% GC)
+median time:      1.863 ns (0.00% GC)
 
-mean time:        1.974 ns (0.00% GC)
+mean time:        1.885 ns (0.00% GC)
 
-maximum time:     33.689 ns (0.00% GC)
+maximum time:     33.668 ns (0.00% GC)
 
 samples:          10000
 
@@ -3269,13 +3269,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.896 ns (0.00% GC)
+minimum time:     1.833 ns (0.00% GC)
 
-median time:      1.905 ns (0.00% GC)
+median time:      1.888 ns (0.00% GC)
 
-mean time:        2.059 ns (0.00% GC)
+mean time:        1.914 ns (0.00% GC)
 
-maximum time:     33.695 ns (0.00% GC)
+maximum time:     33.561 ns (0.00% GC)
 
 samples:          10000
 
@@ -3287,35 +3287,35 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     46.397 ns (0.00% GC)
+minimum time:     64.633 ns (0.00% GC)
 
-median time:      49.430 ns (0.00% GC)
+median time:      66.145 ns (0.00% GC)
 
-mean time:        51.785 ns (0.00% GC)
+mean time:        66.907 ns (0.00% GC)
 
-maximum time:     562.803 ns (0.00% GC)
+maximum time:     137.734 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     985
+evals/sample:     973
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  80 bytes
 
-allocs estimate:  2
+allocs estimate:  3
 
-minimum time:     70.086 ns (0.00% GC)
+minimum time:     91.508 ns (0.00% GC)
 
-median time:      75.618 ns (0.00% GC)
+median time:      94.270 ns (0.00% GC)
 
-mean time:        83.251 ns (5.98% GC)
+mean time:        102.092 ns (5.16% GC)
 
-maximum time:     4.322 μs (97.93% GC)
+maximum time:     4.483 μs (97.69% GC)
 
 samples:          10000
 
-evals/sample:     968
+evals/sample:     932
 
 #### env(GridWorlds.TurnLeft())
 
@@ -3323,53 +3323,53 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     46.343 ns (0.00% GC)
+minimum time:     63.792 ns (0.00% GC)
 
-median time:      49.601 ns (0.00% GC)
+median time:      64.967 ns (0.00% GC)
 
-mean time:        50.762 ns (0.00% GC)
+mean time:        65.778 ns (0.00% GC)
 
-maximum time:     157.432 ns (0.00% GC)
+maximum time:     119.610 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     986
+evals/sample:     974
 
 # SokobanUndirected
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  3.05 MiB
+memory estimate:  2.96 MiB
 
-allocs estimate:  65162
+allocs estimate:  63592
 
-minimum time:     4.557 ms (0.00% GC)
+minimum time:     4.748 ms (0.00% GC)
 
-median time:      4.943 ms (0.00% GC)
+median time:      4.852 ms (0.00% GC)
 
-mean time:        5.477 ms (5.76% GC)
+mean time:        5.156 ms (5.20% GC)
 
-maximum time:     14.020 ms (58.79% GC)
+maximum time:     9.721 ms (41.69% GC)
 
-samples:          914
+samples:          969
 
 evals/sample:     1
 
 #### GridWorlds.SokobanUndirected()
 
-memory estimate:  888.06 KiB
+memory estimate:  794.77 KiB
 
-allocs estimate:  24662
+allocs estimate:  23092
 
-minimum time:     1.478 ms (0.00% GC)
+minimum time:     1.712 ms (0.00% GC)
 
-median time:      1.666 ms (0.00% GC)
+median time:      1.745 ms (0.00% GC)
 
-mean time:        1.968 ms (6.09% GC)
+mean time:        1.828 ms (3.58% GC)
 
-maximum time:     13.373 ms (71.17% GC)
+maximum time:     5.886 ms (68.51% GC)
 
-samples:          2539
+samples:          2729
 
 evals/sample:     1
 
@@ -3379,17 +3379,17 @@ memory estimate:  480 bytes
 
 allocs estimate:  5
 
-minimum time:     1.930 μs (0.00% GC)
+minimum time:     2.333 μs (0.00% GC)
 
-median time:      2.225 μs (0.00% GC)
+median time:      2.597 μs (0.00% GC)
 
-mean time:        2.338 μs (1.47% GC)
+mean time:        2.660 μs (1.35% GC)
 
-maximum time:     347.041 μs (98.83% GC)
+maximum time:     361.525 μs (99.12% GC)
 
 samples:          10000
 
-evals/sample:     10
+evals/sample:     9
 
 #### RLBase.state(env)
 
@@ -3397,17 +3397,17 @@ memory estimate:  192 bytes
 
 allocs estimate:  2
 
-minimum time:     58.677 ns (0.00% GC)
+minimum time:     56.602 ns (0.00% GC)
 
-median time:      60.097 ns (0.00% GC)
+median time:      61.822 ns (0.00% GC)
 
-mean time:        78.186 ns (17.33% GC)
+mean time:        73.459 ns (14.28% GC)
 
-maximum time:     3.653 μs (98.01% GC)
+maximum time:     3.012 μs (97.18% GC)
 
 samples:          10000
 
-evals/sample:     982
+evals/sample:     980
 
 #### RLBase.action_space(env)
 
@@ -3415,13 +3415,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.169 ns (0.00% GC)
+minimum time:     2.172 ns (0.00% GC)
 
-median time:      2.261 ns (0.00% GC)
+median time:      2.203 ns (0.00% GC)
 
-mean time:        2.362 ns (0.00% GC)
+mean time:        2.248 ns (0.00% GC)
 
-maximum time:     34.692 ns (0.00% GC)
+maximum time:     34.184 ns (0.00% GC)
 
 samples:          10000
 
@@ -3433,13 +3433,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.816 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      1.893 ns (0.00% GC)
+median time:      1.852 ns (0.00% GC)
 
-mean time:        2.074 ns (0.00% GC)
+mean time:        1.879 ns (0.00% GC)
 
-maximum time:     33.968 ns (0.00% GC)
+maximum time:     15.026 ns (0.00% GC)
 
 samples:          10000
 
@@ -3451,13 +3451,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.896 ns (0.00% GC)
+minimum time:     1.833 ns (0.00% GC)
 
-median time:      1.907 ns (0.00% GC)
+median time:      1.871 ns (0.00% GC)
 
-mean time:        2.261 ns (0.00% GC)
+mean time:        1.906 ns (0.00% GC)
 
-maximum time:     36.945 ns (0.00% GC)
+maximum time:     33.419 ns (0.00% GC)
 
 samples:          10000
 
@@ -3469,13 +3469,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     44.459 ns (0.00% GC)
+minimum time:     45.737 ns (0.00% GC)
 
-median time:      45.353 ns (0.00% GC)
+median time:      47.226 ns (0.00% GC)
 
-mean time:        49.094 ns (0.00% GC)
+mean time:        47.780 ns (0.00% GC)
 
-maximum time:     141.459 ns (0.00% GC)
+maximum time:     93.679 ns (0.00% GC)
 
 samples:          10000
 
@@ -3487,13 +3487,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     45.042 ns (0.00% GC)
+minimum time:     45.399 ns (0.00% GC)
 
-median time:      47.018 ns (0.00% GC)
+median time:      47.248 ns (0.00% GC)
 
-mean time:        49.824 ns (0.00% GC)
+mean time:        47.770 ns (0.00% GC)
 
-maximum time:     160.096 ns (0.00% GC)
+maximum time:     110.778 ns (0.00% GC)
 
 samples:          10000
 
@@ -3505,17 +3505,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     44.409 ns (0.00% GC)
+minimum time:     46.350 ns (0.00% GC)
 
-median time:      45.223 ns (0.00% GC)
+median time:      48.226 ns (0.00% GC)
 
-mean time:        48.285 ns (0.00% GC)
+mean time:        48.932 ns (0.00% GC)
 
-maximum time:     141.620 ns (0.00% GC)
+maximum time:     87.208 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     988
+evals/sample:     986
 
 #### env(GridWorlds.MoveRight())
 
@@ -3523,17 +3523,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     48.574 ns (0.00% GC)
+minimum time:     50.191 ns (0.00% GC)
 
-median time:      49.220 ns (0.00% GC)
+median time:      51.724 ns (0.00% GC)
 
-mean time:        51.128 ns (0.00% GC)
+mean time:        52.493 ns (0.00% GC)
 
-maximum time:     124.618 ns (0.00% GC)
+maximum time:     120.401 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     985
+evals/sample:     984
 
 # Snake
 
@@ -3543,15 +3543,15 @@ memory estimate:  1.69 MiB
 
 allocs estimate:  40012
 
-minimum time:     16.533 ms (0.00% GC)
+minimum time:     16.189 ms (0.00% GC)
 
-median time:      16.891 ms (0.00% GC)
+median time:      16.452 ms (0.00% GC)
 
-mean time:        17.305 ms (1.31% GC)
+mean time:        16.777 ms (1.11% GC)
 
-maximum time:     24.352 ms (25.42% GC)
+maximum time:     32.484 ms (0.00% GC)
 
-samples:          289
+samples:          298
 
 evals/sample:     1
 
@@ -3561,17 +3561,17 @@ memory estimate:  16.59 KiB
 
 allocs estimate:  12
 
-minimum time:     1.954 μs (0.00% GC)
+minimum time:     1.607 μs (0.00% GC)
 
-median time:      2.114 μs (0.00% GC)
+median time:      1.742 μs (0.00% GC)
 
-mean time:        2.898 μs (24.31% GC)
+mean time:        2.192 μs (17.28% GC)
 
-maximum time:     262.119 μs (95.30% GC)
+maximum time:     146.341 μs (95.70% GC)
 
 samples:          10000
 
-evals/sample:     9
+evals/sample:     10
 
 #### RLBase.reset!(env)
 
@@ -3579,17 +3579,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     209.496 ns (0.00% GC)
+minimum time:     178.461 ns (0.00% GC)
 
-median time:      227.877 ns (0.00% GC)
+median time:      191.985 ns (0.00% GC)
 
-mean time:        231.756 ns (0.00% GC)
+mean time:        193.268 ns (0.00% GC)
 
-maximum time:     510.431 ns (0.00% GC)
+maximum time:     349.543 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     506
+evals/sample:     681
 
 #### RLBase.state(env)
 
@@ -3597,13 +3597,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.602 μs (0.00% GC)
+minimum time:     1.305 μs (0.00% GC)
 
-median time:      1.641 μs (0.00% GC)
+median time:      1.326 μs (0.00% GC)
 
-mean time:        1.713 μs (0.00% GC)
+mean time:        1.376 μs (0.00% GC)
 
-maximum time:     5.529 μs (0.00% GC)
+maximum time:     3.191 μs (0.00% GC)
 
 samples:          10000
 
@@ -3615,13 +3615,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.530 ns (0.00% GC)
+minimum time:     2.442 ns (0.00% GC)
 
-median time:      2.635 ns (0.00% GC)
+median time:      2.540 ns (0.00% GC)
 
-mean time:        2.717 ns (0.00% GC)
+mean time:        2.598 ns (0.00% GC)
 
-maximum time:     39.108 ns (0.00% GC)
+maximum time:     16.109 ns (0.00% GC)
 
 samples:          10000
 
@@ -3633,13 +3633,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.819 ns (0.00% GC)
 
-median time:      1.892 ns (0.00% GC)
+median time:      1.848 ns (0.00% GC)
 
-mean time:        1.973 ns (0.00% GC)
+mean time:        1.879 ns (0.00% GC)
 
-maximum time:     37.036 ns (0.00% GC)
+maximum time:     15.479 ns (0.00% GC)
 
 samples:          10000
 
@@ -3651,13 +3651,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.880 ns (0.00% GC)
+minimum time:     1.817 ns (0.00% GC)
 
-median time:      1.892 ns (0.00% GC)
+median time:      1.838 ns (0.00% GC)
 
-mean time:        1.960 ns (0.00% GC)
+mean time:        1.876 ns (0.00% GC)
 
-maximum time:     38.571 ns (0.00% GC)
+maximum time:     33.647 ns (0.00% GC)
 
 samples:          10000
 
@@ -3669,13 +3669,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.310 ns (0.00% GC)
+minimum time:     12.388 ns (0.00% GC)
 
-median time:      12.394 ns (0.00% GC)
+median time:      12.818 ns (0.00% GC)
 
-mean time:        13.552 ns (0.00% GC)
+mean time:        13.406 ns (0.00% GC)
 
-maximum time:     48.078 ns (0.00% GC)
+maximum time:     51.005 ns (0.00% GC)
 
 samples:          10000
 
@@ -3687,13 +3687,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.307 ns (0.00% GC)
+minimum time:     12.165 ns (0.00% GC)
 
-median time:      12.732 ns (0.00% GC)
+median time:      12.774 ns (0.00% GC)
 
-mean time:        13.580 ns (0.00% GC)
+mean time:        13.258 ns (0.00% GC)
 
-maximum time:     87.071 ns (0.00% GC)
+maximum time:     46.593 ns (0.00% GC)
 
 samples:          10000
 
@@ -3705,13 +3705,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.618 ns (0.00% GC)
+minimum time:     12.810 ns (0.00% GC)
 
-median time:      12.702 ns (0.00% GC)
+median time:      13.143 ns (0.00% GC)
 
-mean time:        13.442 ns (0.00% GC)
+mean time:        13.766 ns (0.00% GC)
 
-maximum time:     46.216 ns (0.00% GC)
+maximum time:     48.313 ns (0.00% GC)
 
 samples:          10000
 
@@ -3723,13 +3723,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.304 ns (0.00% GC)
+minimum time:     12.391 ns (0.00% GC)
 
-median time:      12.609 ns (0.00% GC)
+median time:      12.781 ns (0.00% GC)
 
-mean time:        13.299 ns (0.00% GC)
+mean time:        13.278 ns (0.00% GC)
 
-maximum time:     46.508 ns (0.00% GC)
+maximum time:     46.584 ns (0.00% GC)
 
 samples:          10000
 
@@ -3743,15 +3743,15 @@ memory estimate:  1.68 MiB
 
 allocs estimate:  40007
 
-minimum time:     2.454 ms (0.00% GC)
+minimum time:     2.373 ms (0.00% GC)
 
-median time:      2.595 ms (0.00% GC)
+median time:      2.437 ms (0.00% GC)
 
-mean time:        2.864 ms (8.02% GC)
+mean time:        2.648 ms (7.20% GC)
 
-maximum time:     9.504 ms (66.39% GC)
+maximum time:     7.822 ms (66.67% GC)
 
-samples:          1747
+samples:          1886
 
 evals/sample:     1
 
@@ -3761,17 +3761,17 @@ memory estimate:  304 bytes
 
 allocs estimate:  7
 
-minimum time:     987.100 ns (0.00% GC)
+minimum time:     766.557 ns (0.00% GC)
 
-median time:      1.115 μs (0.00% GC)
+median time:      779.929 ns (0.00% GC)
 
-mean time:        1.147 μs (0.00% GC)
+mean time:        837.045 ns (5.08% GC)
 
-maximum time:     6.309 μs (0.00% GC)
+maximum time:     63.773 μs (98.44% GC)
 
 samples:          10000
 
-evals/sample:     10
+evals/sample:     106
 
 #### RLBase.reset!(env)
 
@@ -3779,17 +3779,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     32.114 ns (0.00% GC)
+minimum time:     28.488 ns (0.00% GC)
 
-median time:      34.652 ns (0.00% GC)
+median time:      30.373 ns (0.00% GC)
 
-mean time:        35.830 ns (0.00% GC)
+mean time:        30.946 ns (0.00% GC)
 
-maximum time:     116.173 ns (0.00% GC)
+maximum time:     66.970 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     992
+evals/sample:     994
 
 #### RLBase.state(env)
 
@@ -3797,17 +3797,17 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     55.167 ns (0.00% GC)
+minimum time:     54.285 ns (0.00% GC)
 
-median time:      56.677 ns (0.00% GC)
+median time:      58.411 ns (0.00% GC)
 
-mean time:        75.630 ns (21.89% GC)
+mean time:        72.218 ns (17.31% GC)
 
-maximum time:     5.925 μs (98.31% GC)
+maximum time:     4.563 μs (98.35% GC)
 
 samples:          10000
 
-evals/sample:     984
+evals/sample:     983
 
 #### RLBase.action_space(env)
 
@@ -3815,13 +3815,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     2.531 ns (0.00% GC)
+minimum time:     2.442 ns (0.00% GC)
 
-median time:      2.633 ns (0.00% GC)
+median time:      2.548 ns (0.00% GC)
 
-mean time:        2.687 ns (0.00% GC)
+mean time:        2.595 ns (0.00% GC)
 
-maximum time:     39.443 ns (0.00% GC)
+maximum time:     34.386 ns (0.00% GC)
 
 samples:          10000
 
@@ -3833,13 +3833,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.881 ns (0.00% GC)
+minimum time:     1.818 ns (0.00% GC)
 
-median time:      1.894 ns (0.00% GC)
+median time:      1.856 ns (0.00% GC)
 
-mean time:        1.966 ns (0.00% GC)
+mean time:        1.886 ns (0.00% GC)
 
-maximum time:     38.695 ns (0.00% GC)
+maximum time:     33.750 ns (0.00% GC)
 
 samples:          10000
 
@@ -3851,13 +3851,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.879 ns (0.00% GC)
+minimum time:     1.833 ns (0.00% GC)
 
-median time:      1.891 ns (0.00% GC)
+median time:      1.892 ns (0.00% GC)
 
-mean time:        1.951 ns (0.00% GC)
+mean time:        1.903 ns (0.00% GC)
 
-maximum time:     14.966 ns (0.00% GC)
+maximum time:     15.539 ns (0.00% GC)
 
 samples:          10000
 
@@ -3869,13 +3869,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     18.957 ns (0.00% GC)
+minimum time:     18.817 ns (0.00% GC)
 
-median time:      19.163 ns (0.00% GC)
+median time:      19.103 ns (0.00% GC)
 
-mean time:        20.165 ns (0.00% GC)
+mean time:        20.000 ns (0.00% GC)
 
-maximum time:     97.250 ns (0.00% GC)
+maximum time:     78.770 ns (0.00% GC)
 
 samples:          10000
 
@@ -3887,17 +3887,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     19.201 ns (0.00% GC)
+minimum time:     18.845 ns (0.00% GC)
 
-median time:      19.811 ns (0.00% GC)
+median time:      19.381 ns (0.00% GC)
 
-mean time:        20.615 ns (0.00% GC)
+mean time:        20.212 ns (0.00% GC)
 
-maximum time:     67.627 ns (0.00% GC)
+maximum time:     54.324 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     996
+evals/sample:     997
 
 #### env(GridWorlds.MoveRight())
 
@@ -3905,13 +3905,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     19.419 ns (0.00% GC)
+minimum time:     19.273 ns (0.00% GC)
 
-median time:      19.769 ns (0.00% GC)
+median time:      19.564 ns (0.00% GC)
 
-mean time:        21.157 ns (0.00% GC)
+mean time:        20.286 ns (0.00% GC)
 
-maximum time:     91.532 ns (0.00% GC)
+maximum time:     63.100 ns (0.00% GC)
 
 samples:          10000
 
@@ -3921,19 +3921,19 @@ evals/sample:     996
 
 #### Run uniformly random policy, NUM_RESETS = 100, STEPS_PER_RESET = 100, TOTAL_STEPS = 10000
 
-memory estimate:  2.56 MiB
+memory estimate:  2.61 MiB
 
-allocs estimate:  73784
+allocs estimate:  77093
 
-minimum time:     14.803 ms (0.00% GC)
+minimum time:     15.596 ms (0.00% GC)
 
-median time:      15.284 ms (0.00% GC)
+median time:      16.054 ms (0.00% GC)
 
-mean time:        15.867 ms (2.56% GC)
+mean time:        16.843 ms (2.02% GC)
 
-maximum time:     24.919 ms (28.97% GC)
+maximum time:     28.150 ms (0.00% GC)
 
-samples:          316
+samples:          297
 
 evals/sample:     1
 
@@ -3943,13 +3943,13 @@ memory estimate:  336 bytes
 
 allocs estimate:  6
 
-minimum time:     1.428 μs (0.00% GC)
+minimum time:     1.049 μs (0.00% GC)
 
-median time:      1.699 μs (0.00% GC)
+median time:      1.291 μs (0.00% GC)
 
-mean time:        1.752 μs (0.00% GC)
+mean time:        1.298 μs (0.00% GC)
 
-maximum time:     7.059 μs (0.00% GC)
+maximum time:     4.631 μs (0.00% GC)
 
 samples:          10000
 
@@ -3961,17 +3961,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     351.285 ns (0.00% GC)
+minimum time:     309.047 ns (0.00% GC)
 
-median time:      382.082 ns (0.00% GC)
+median time:      341.957 ns (0.00% GC)
 
-mean time:        390.668 ns (0.00% GC)
+mean time:        371.535 ns (0.00% GC)
 
-maximum time:     1.022 μs (0.00% GC)
+maximum time:     784.901 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     207
+evals/sample:     233
 
 #### RLBase.state(env)
 
@@ -3979,17 +3979,17 @@ memory estimate:  224 bytes
 
 allocs estimate:  5
 
-minimum time:     922.133 ns (0.00% GC)
+minimum time:     1.379 μs (0.00% GC)
 
-median time:      942.667 ns (0.00% GC)
+median time:      1.428 μs (0.00% GC)
 
-mean time:        1.016 μs (2.36% GC)
+mean time:        1.482 μs (0.00% GC)
 
-maximum time:     240.934 μs (99.46% GC)
+maximum time:     4.887 μs (0.00% GC)
 
 samples:          10000
 
-evals/sample:     30
+evals/sample:     10
 
 #### RLBase.action_space(env)
 
@@ -3997,13 +3997,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     2.528 ns (0.00% GC)
 
-median time:      1.895 ns (0.00% GC)
+median time:      2.552 ns (0.00% GC)
 
-mean time:        1.965 ns (0.00% GC)
+mean time:        2.605 ns (0.00% GC)
 
-maximum time:     34.106 ns (0.00% GC)
+maximum time:     34.059 ns (0.00% GC)
 
 samples:          10000
 
@@ -4015,13 +4015,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     1.817 ns (0.00% GC)
 
-median time:      1.895 ns (0.00% GC)
+median time:      1.888 ns (0.00% GC)
 
-mean time:        1.964 ns (0.00% GC)
+mean time:        1.894 ns (0.00% GC)
 
-maximum time:     34.176 ns (0.00% GC)
+maximum time:     33.548 ns (0.00% GC)
 
 samples:          10000
 
@@ -4033,13 +4033,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.896 ns (0.00% GC)
+minimum time:     1.833 ns (0.00% GC)
 
-median time:      1.907 ns (0.00% GC)
+median time:      1.892 ns (0.00% GC)
 
-mean time:        1.980 ns (0.00% GC)
+mean time:        1.904 ns (0.00% GC)
 
-maximum time:     34.325 ns (0.00% GC)
+maximum time:     15.683 ns (0.00% GC)
 
 samples:          10000
 
@@ -4051,17 +4051,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     45.044 ns (0.00% GC)
+minimum time:     62.290 ns (0.00% GC)
 
-median time:      46.390 ns (0.00% GC)
+median time:      63.983 ns (0.00% GC)
 
-mean time:        48.243 ns (0.00% GC)
+mean time:        64.676 ns (0.00% GC)
 
-maximum time:     139.694 ns (0.00% GC)
+maximum time:     115.749 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     988
+evals/sample:     976
 
 #### env(GridWorlds.Drop())
 
@@ -4069,13 +4069,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     9.068 ns (0.00% GC)
+minimum time:     10.395 ns (0.00% GC)
 
-median time:      9.769 ns (0.00% GC)
+median time:      10.716 ns (0.00% GC)
 
-mean time:        9.907 ns (0.00% GC)
+mean time:        11.212 ns (0.00% GC)
 
-maximum time:     47.491 ns (0.00% GC)
+maximum time:     44.625 ns (0.00% GC)
 
 samples:          10000
 
@@ -4087,13 +4087,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     11.361 ns (0.00% GC)
+minimum time:     12.834 ns (0.00% GC)
 
-median time:      12.332 ns (0.00% GC)
+median time:      13.751 ns (0.00% GC)
 
-mean time:        12.956 ns (0.00% GC)
+mean time:        14.225 ns (0.00% GC)
 
-maximum time:     46.299 ns (0.00% GC)
+maximum time:     51.161 ns (0.00% GC)
 
 samples:          10000
 
@@ -4101,21 +4101,21 @@ evals/sample:     998
 
 #### env(GridWorlds.MoveForward())
 
-memory estimate:  64 bytes
+memory estimate:  80 bytes
 
-allocs estimate:  2
+allocs estimate:  3
 
-minimum time:     41.097 ns (0.00% GC)
+minimum time:     71.199 ns (0.00% GC)
 
-median time:      45.768 ns (0.00% GC)
+median time:      72.970 ns (0.00% GC)
 
-mean time:        52.079 ns (9.42% GC)
+mean time:        83.554 ns (6.41% GC)
 
-maximum time:     4.127 μs (98.62% GC)
+maximum time:     3.777 μs (97.36% GC)
 
 samples:          10000
 
-evals/sample:     987
+evals/sample:     966
 
 #### env(GridWorlds.TurnLeft())
 
@@ -4123,17 +4123,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     44.697 ns (0.00% GC)
+minimum time:     61.074 ns (0.00% GC)
 
-median time:      46.151 ns (0.00% GC)
+median time:      62.992 ns (0.00% GC)
 
-mean time:        47.629 ns (0.00% GC)
+mean time:        67.443 ns (0.00% GC)
 
-maximum time:     178.077 ns (0.00% GC)
+maximum time:     1.801 μs (0.00% GC)
 
 samples:          10000
 
-evals/sample:     988
+evals/sample:     976
 
 # TransportUndirected
 
@@ -4143,15 +4143,15 @@ memory estimate:  1.68 MiB
 
 allocs estimate:  40006
 
-minimum time:     16.735 ms (0.00% GC)
+minimum time:     16.984 ms (0.00% GC)
 
-median time:      17.147 ms (0.00% GC)
+median time:      17.716 ms (0.00% GC)
 
-mean time:        17.621 ms (1.24% GC)
+mean time:        19.407 ms (1.12% GC)
 
-maximum time:     25.408 ms (23.75% GC)
+maximum time:     44.158 ms (0.00% GC)
 
-samples:          284
+samples:          258
 
 evals/sample:     1
 
@@ -4161,13 +4161,13 @@ memory estimate:  320 bytes
 
 allocs estimate:  6
 
-minimum time:     1.350 μs (0.00% GC)
+minimum time:     1.015 μs (0.00% GC)
 
-median time:      1.589 μs (0.00% GC)
+median time:      1.210 μs (0.00% GC)
 
-mean time:        1.604 μs (0.00% GC)
+mean time:        1.218 μs (0.00% GC)
 
-maximum time:     4.960 μs (0.00% GC)
+maximum time:     4.544 μs (0.00% GC)
 
 samples:          10000
 
@@ -4179,17 +4179,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     295.979 ns (0.00% GC)
+minimum time:     250.478 ns (0.00% GC)
 
-median time:      329.977 ns (0.00% GC)
+median time:      274.767 ns (0.00% GC)
 
-mean time:        336.358 ns (0.00% GC)
+mean time:        285.521 ns (0.00% GC)
 
-maximum time:     800.623 ns (0.00% GC)
+maximum time:     654.415 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     236
+evals/sample:     337
 
 #### RLBase.state(env)
 
@@ -4197,13 +4197,13 @@ memory estimate:  144 bytes
 
 allocs estimate:  2
 
-minimum time:     1.605 μs (0.00% GC)
+minimum time:     1.303 μs (0.00% GC)
 
-median time:      1.647 μs (0.00% GC)
+median time:      1.375 μs (0.00% GC)
 
-mean time:        1.725 μs (0.00% GC)
+mean time:        1.437 μs (0.00% GC)
 
-maximum time:     6.492 μs (0.00% GC)
+maximum time:     6.795 μs (0.00% GC)
 
 samples:          10000
 
@@ -4215,13 +4215,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     2.527 ns (0.00% GC)
 
-median time:      1.892 ns (0.00% GC)
+median time:      2.624 ns (0.00% GC)
 
-mean time:        1.980 ns (0.00% GC)
+mean time:        2.650 ns (0.00% GC)
 
-maximum time:     36.404 ns (0.00% GC)
+maximum time:     36.558 ns (0.00% GC)
 
 samples:          10000
 
@@ -4233,13 +4233,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.882 ns (0.00% GC)
+minimum time:     1.819 ns (0.00% GC)
 
-median time:      1.894 ns (0.00% GC)
+median time:      2.215 ns (0.00% GC)
 
-mean time:        1.962 ns (0.00% GC)
+mean time:        2.332 ns (0.00% GC)
 
-maximum time:     37.314 ns (0.00% GC)
+maximum time:     136.714 ns (0.00% GC)
 
 samples:          10000
 
@@ -4251,13 +4251,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     1.897 ns (0.00% GC)
+minimum time:     1.833 ns (0.00% GC)
 
-median time:      1.935 ns (0.00% GC)
+median time:      3.312 ns (0.00% GC)
 
-mean time:        2.019 ns (0.00% GC)
+mean time:        3.073 ns (0.00% GC)
 
-maximum time:     33.481 ns (0.00% GC)
+maximum time:     35.290 ns (0.00% GC)
 
 samples:          10000
 
@@ -4269,17 +4269,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.006 ns (0.00% GC)
+minimum time:     12.868 ns (0.00% GC)
 
-median time:      12.618 ns (0.00% GC)
+median time:      13.783 ns (0.00% GC)
 
-mean time:        13.370 ns (0.00% GC)
+mean time:        14.667 ns (0.00% GC)
 
-maximum time:     47.062 ns (0.00% GC)
+maximum time:     57.126 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     998
+evals/sample:     995
 
 #### env(GridWorlds.MoveUp())
 
@@ -4287,17 +4287,17 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.519 ns (0.00% GC)
+minimum time:     12.304 ns (0.00% GC)
 
-median time:      12.821 ns (0.00% GC)
+median time:      14.053 ns (0.00% GC)
 
-mean time:        13.591 ns (0.00% GC)
+mean time:        15.189 ns (0.00% GC)
 
-maximum time:     52.441 ns (0.00% GC)
+maximum time:     64.762 ns (0.00% GC)
 
 samples:          10000
 
-evals/sample:     998
+evals/sample:     997
 
 #### env(GridWorlds.MoveLeft())
 
@@ -4305,13 +4305,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.308 ns (0.00% GC)
+minimum time:     12.573 ns (0.00% GC)
 
-median time:      12.713 ns (0.00% GC)
+median time:      13.460 ns (0.00% GC)
 
-mean time:        13.390 ns (0.00% GC)
+mean time:        14.444 ns (0.00% GC)
 
-maximum time:     48.915 ns (0.00% GC)
+maximum time:     70.662 ns (0.00% GC)
 
 samples:          10000
 
@@ -4323,13 +4323,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.301 ns (0.00% GC)
+minimum time:     14.006 ns (0.00% GC)
 
-median time:      12.564 ns (0.00% GC)
+median time:      24.031 ns (0.00% GC)
 
-mean time:        13.308 ns (0.00% GC)
+mean time:        22.799 ns (0.00% GC)
 
-maximum time:     52.666 ns (0.00% GC)
+maximum time:     98.804 ns (0.00% GC)
 
 samples:          10000
 
@@ -4341,13 +4341,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     12.217 ns (0.00% GC)
+minimum time:     13.037 ns (0.00% GC)
 
-median time:      13.157 ns (0.00% GC)
+median time:      14.015 ns (0.00% GC)
 
-mean time:        13.554 ns (0.00% GC)
+mean time:        15.263 ns (0.00% GC)
 
-maximum time:     46.351 ns (0.00% GC)
+maximum time:     66.433 ns (0.00% GC)
 
 samples:          10000
 
@@ -4359,13 +4359,13 @@ memory estimate:  0 bytes
 
 allocs estimate:  0
 
-minimum time:     9.411 ns (0.00% GC)
+minimum time:     10.367 ns (0.00% GC)
 
-median time:      9.808 ns (0.00% GC)
+median time:      11.096 ns (0.00% GC)
 
-mean time:        10.173 ns (0.00% GC)
+mean time:        11.750 ns (0.00% GC)
 
-maximum time:     50.119 ns (0.00% GC)
+maximum time:     73.167 ns (0.00% GC)
 
 samples:          10000
 

--- a/src/grid_world_base.jl
+++ b/src/grid_world_base.jl
@@ -41,11 +41,41 @@ Base.setindex!(world::GridWorldBase, value::Bool, object::AbstractObject, args..
 # methods for agent view
 #####
 
-get_grid_inds((i, j), (m, n)) = CartesianIndices((i-m÷2:i-m÷2+m-1, j-n÷2:j-n÷2+n-1))
-get_grid_inds((i, j), (m, n), ::Up) = CartesianIndices((i-m+1:i, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
-get_grid_inds((i, j), (m, n), ::Down) = CartesianIndices((i:i+m-1, j-(n-1)÷2:j+(n-(n-1)÷2)-1))
-get_grid_inds((i, j), (m, n), ::Left) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j-m+1:j))
-get_grid_inds((i, j), (m, n), ::Right) = CartesianIndices((i-(n-1)÷2:i+(n-(n-1)÷2)-1, j:j+m-1))
+function get_grid_inds((i, j), (m, n))
+    temp1 = m ÷ 2
+    temp2 = i - temp1
+    temp3 = n ÷ 2
+    temp4 = j - temp3
+    return CartesianIndices((temp2 : temp2 + m - 1, temp4 : temp4 + n - 1))
+end
+
+function get_grid_inds((i, j), (m, n), ::Up)
+    temp1 = n - 1
+    temp2 = temp1 ÷ 2
+    temp3 = j - temp2
+    return CartesianIndices((i - m + 1 : i, temp3 : temp3 + temp1))
+end
+
+function get_grid_inds((i, j), (m, n), ::Down)
+    temp1 = n - 1
+    temp2 = temp1 ÷ 2
+    temp3 = j - temp2
+    return CartesianIndices((i : i + m - 1, temp3 : temp3 + temp1))
+end
+
+function get_grid_inds((i, j), (m, n), ::Left)
+    temp1 = n - 1
+    temp2 = temp1 ÷ 2
+    temp3 = i - temp2
+    return CartesianIndices((temp3 : temp3 + temp1, j - m + 1 : j))
+end
+
+function get_grid_inds((i, j), (m, n), ::Right)
+    temp1 = n - 1
+    temp2 = temp1 ÷ 2
+    temp3 = i - temp2
+    return CartesianIndices((temp3 : temp3 + temp1, j : j + m - 1))
+end
 
 map_ind((i,j), (m, n), ::Up) = (m-i+1, n-j+1)
 map_ind((i,j), (m, n), ::Down) = (i,j)


### PR DESCRIPTION
1. Add compat entry for `StaticArrays`.
2. Reuse computation within `get_grid_inds` methods.
3. Update `benchmark.md`.