### PR TITLE
update bunch of miscellaneous things

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A package for creating grid world environments for reinforcement learning in Jul
 
 This package is inspired by [gym-minigrid](https://github.com/maximecb/gym-minigrid). In order to cite this package, please refer to the file `CITATION.bib`. Starring the repository on GitHub is also appreciated. For benchmarks, refer to `benchmark/benchmarks.md`.
 
-**Important note:** This package is undergoing heavy internal redesign. This README reflects the new design. The README for the last released version (`0.4.0`) can be found [here](https://github.com/JuliaReinforcementLearning/GridWorlds.jl/tree/c0e86bb6c33819f0e4a4cefe0284d985d0474ed3).
+**Important note:** This package is undergoing heavy internal redesign. This README reflects the new design (some visualizations might be oudated). The README for the last released version (`0.4.0`) can be found [here](https://github.com/JuliaReinforcementLearning/GridWorlds.jl/tree/c0e86bb6c33819f0e4a4cefe0284d985d0474ed3).
 
 ## Table of contents:
 

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -22,7 +22,7 @@ end
 function benchmark(Env, num_resets, steps_per_reset)
     benchmark = DS.OrderedDict()
 
-    env = GW.RLBaseEnvModule.RLBaseEnv(Env())
+    env = GW.RLBaseEnv(Env())
 
     benchmark[:random_policy] = BT.@benchmark run_random_policy!($(Ref(env))[], $(Ref(num_resets))[], $(Ref(steps_per_reset))[])
     benchmark[:reset] = BT.@benchmark RLBase.reset!($(Ref(env))[])

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -15,20 +15,20 @@ get_tile_pretty_repr(env::AbstractGridWorld, i::Integer, j::Integer) = error("Me
 get_sub_tile_map_pretty_repr(env::AbstractGridWorld, position::CartesianIndex{2}) = error("Method not implemented for $(typeof(env))")
 get_action_keys(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_action_names(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
-get_tile_map_height(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
-get_tile_map_width(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
+get_height(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
+get_width(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 
 function get_tile_map_pretty_repr(env::AbstractGridWorld)
-    height_tile_map = get_tile_map_height(env)
-    width_tile_map = get_tile_map_width(env)
+    height = get_height(env)
+    width = get_width(env)
 
     str = ""
 
-    for i in 1:height_tile_map
-        for j in 1:width_tile_map
+    for i in 1:height
+        for j in 1:width
             str = str * get_tile_pretty_repr(env, i, j)
         end
-        if i < height_tile_map
+        if i < height
             str = str * "\n"
         end
     end
@@ -37,21 +37,21 @@ function get_tile_map_pretty_repr(env::AbstractGridWorld)
 end
 
 function get_window_size(env::AbstractGridWorld)
-    height = get_tile_map_height(env)
-    width = get_tile_map_width(env)
+    height = get_height(env)
+    width = get_width(env)
     return (2 * (height ÷ 4) + 1, 2 * (width ÷ 4) + 1)
 end
 
 function get_sub_tile_map_pretty_repr(env::AbstractGridWorld, window_size)
-    height_sub_tile_map, width_sub_tile_map = window_size
+    height, width = window_size
 
     str = ""
 
-    for i in 1:height_sub_tile_map
-        for j in 1:width_sub_tile_map
+    for i in 1:height
+        for j in 1:width
             str = str * get_sub_tile_map_pretty_repr(env, window_size, CartesianIndex(i, j))
         end
-        if i < height_sub_tile_map
+        if i < height
             str = str * "\n"
         end
     end

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -15,6 +15,7 @@ get_pretty_tile_map(env::AbstractGridWorld, i::Integer, j::Integer) = error("Met
 get_pretty_sub_tile_map(env::AbstractGridWorld, position::CartesianIndex{2}) = error("Method not implemented for $(typeof(env))")
 get_action_keys(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_action_names(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
+get_object_names(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_height(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_width(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 
@@ -26,7 +27,7 @@ function get_pretty_tile_map(env::AbstractGridWorld)
 
     for i in 1:height
         for j in 1:width
-            str = str * get_pretty_tile_map(env, i, j)
+            str = str * get_pretty_tile_map(env, CartesianIndex(i, j))
         end
         if i < height
             str = str * "\n"

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -11,14 +11,14 @@ act!(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))"
 ##### Optional methods for pretty printing, playing, etc...
 #####
 
-get_tile_pretty_repr(env::AbstractGridWorld, i::Integer, j::Integer) = error("Method not implemented for $(typeof(env))")
+get_pretty_tile_map(env::AbstractGridWorld, i::Integer, j::Integer) = error("Method not implemented for $(typeof(env))")
 get_sub_tile_map_pretty_repr(env::AbstractGridWorld, position::CartesianIndex{2}) = error("Method not implemented for $(typeof(env))")
 get_action_keys(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_action_names(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_height(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_width(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 
-function get_tile_map_pretty_repr(env::AbstractGridWorld)
+function get_pretty_tile_map(env::AbstractGridWorld)
     height = get_height(env)
     width = get_width(env)
 
@@ -26,7 +26,7 @@ function get_tile_map_pretty_repr(env::AbstractGridWorld)
 
     for i in 1:height
         for j in 1:width
-            str = str * get_tile_pretty_repr(env, i, j)
+            str = str * get_pretty_tile_map(env, i, j)
         end
         if i < height
             str = str * "\n"

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -1,24 +1,24 @@
-abstract type AbstractGridWorldGame end
+abstract type AbstractGridWorld end
 
 #####
 ##### Game logic methods
 #####
 
-reset!(env::AbstractGridWorldGame) = error("Method not implemented for $(typeof(env))")
-act!(env::AbstractGridWorldGame) = error("Method not implemented for $(typeof(env))")
+reset!(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
+act!(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 
 #####
 ##### Optional methods for pretty printing, playing, etc...
 #####
 
-get_tile_pretty_repr(env::AbstractGridWorldGame, i::Integer, j::Integer) = error("Method not implemented for $(typeof(env))")
-get_sub_tile_map_pretty_repr(env::AbstractGridWorldGame, position::CartesianIndex{2}) = error("Method not implemented for $(typeof(env))")
-get_action_keys(env::AbstractGridWorldGame) = error("Method not implemented for $(typeof(env))")
-get_action_names(env::AbstractGridWorldGame) = error("Method not implemented for $(typeof(env))")
-get_tile_map_height(env::AbstractGridWorldGame) = error("Method not implemented for $(typeof(env))")
-get_tile_map_width(env::AbstractGridWorldGame) = error("Method not implemented for $(typeof(env))")
+get_tile_pretty_repr(env::AbstractGridWorld, i::Integer, j::Integer) = error("Method not implemented for $(typeof(env))")
+get_sub_tile_map_pretty_repr(env::AbstractGridWorld, position::CartesianIndex{2}) = error("Method not implemented for $(typeof(env))")
+get_action_keys(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
+get_action_names(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
+get_tile_map_height(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
+get_tile_map_width(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 
-function get_tile_map_pretty_repr(env::AbstractGridWorldGame)
+function get_tile_map_pretty_repr(env::AbstractGridWorld)
     height_tile_map = get_tile_map_height(env)
     width_tile_map = get_tile_map_width(env)
 
@@ -36,13 +36,13 @@ function get_tile_map_pretty_repr(env::AbstractGridWorldGame)
     return str
 end
 
-function get_window_size(env::AbstractGridWorldGame)
+function get_window_size(env::AbstractGridWorld)
     height = get_tile_map_height(env)
     width = get_tile_map_width(env)
     return (2 * (height ÷ 4) + 1, 2 * (width ÷ 4) + 1)
 end
 
-function get_sub_tile_map_pretty_repr(env::AbstractGridWorldGame, window_size)
+function get_sub_tile_map_pretty_repr(env::AbstractGridWorld, window_size)
     height_sub_tile_map, width_sub_tile_map = window_size
 
     str = ""

--- a/src/abstract_grid_world.jl
+++ b/src/abstract_grid_world.jl
@@ -12,7 +12,7 @@ act!(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))"
 #####
 
 get_pretty_tile_map(env::AbstractGridWorld, i::Integer, j::Integer) = error("Method not implemented for $(typeof(env))")
-get_sub_tile_map_pretty_repr(env::AbstractGridWorld, position::CartesianIndex{2}) = error("Method not implemented for $(typeof(env))")
+get_pretty_sub_tile_map(env::AbstractGridWorld, position::CartesianIndex{2}) = error("Method not implemented for $(typeof(env))")
 get_action_keys(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_action_names(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
 get_height(env::AbstractGridWorld) = error("Method not implemented for $(typeof(env))")
@@ -42,14 +42,14 @@ function get_window_size(env::AbstractGridWorld)
     return (2 * (height ÷ 4) + 1, 2 * (width ÷ 4) + 1)
 end
 
-function get_sub_tile_map_pretty_repr(env::AbstractGridWorld, window_size)
+function get_pretty_sub_tile_map(env::AbstractGridWorld, window_size)
     height, width = window_size
 
     str = ""
 
     for i in 1:height
         for j in 1:width
-            str = str * get_sub_tile_map_pretty_repr(env, window_size, CartesianIndex(i, j))
+            str = str * get_pretty_sub_tile_map(env, window_size, CartesianIndex(i, j))
         end
         if i < height
             str = str * "\n"

--- a/src/envs/catcher.jl
+++ b/src/envs/catcher.jl
@@ -159,7 +159,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: Catcher} 
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: Catcher} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: Catcher} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: Catcher} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: Catcher} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: Catcher} = env.env.reward

--- a/src/envs/catcher.jl
+++ b/src/envs/catcher.jl
@@ -13,7 +13,7 @@ const AGENT = 1
 const GEM = 2
 const NUM_ACTIONS = 3
 
-mutable struct Catcher{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct Catcher{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/catcher.jl
+++ b/src/envs/catcher.jl
@@ -130,7 +130,7 @@ CHARACTERS = ('☻', '♦', '⋅')
 GW.get_height(env::Catcher) = size(env.tile_map, 2)
 GW.get_width(env::Catcher) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::Catcher, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::Catcher, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -143,7 +143,7 @@ GW.get_action_keys(env::Catcher) = ('a', 'd', 's')
 GW.get_action_names(env::Catcher) = (:MOVE_LEFT, :MOVE_RIGHT, :NO_MOVE)
 
 function Base.show(io::IO, ::MIME"text/plain", env::Catcher)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/catcher.jl
+++ b/src/envs/catcher.jl
@@ -125,29 +125,34 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '♦', '⋅')
-
 GW.get_height(env::Catcher) = size(env.tile_map, 2)
 GW.get_width(env::Catcher) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::Catcher, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::Catcher, position::CartesianIndex{2})
+    characters = ('☻', '♦', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::Catcher) = ('a', 'd', 's')
+GW.get_object_names(env::Catcher) = (:AGENT, :GEM)
 GW.get_action_names(env::Catcher) = (:MOVE_LEFT, :MOVE_RIGHT, :NO_MOVE)
 
 function Base.show(io::IO, ::MIME"text/plain", env::Catcher)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nreward: $(env.reward)\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::Catcher) = ('a', 'd', 's')
 
 #####
 ##### RLBase API

--- a/src/envs/catcher.jl
+++ b/src/envs/catcher.jl
@@ -127,8 +127,8 @@ end
 
 CHARACTERS = ('☻', '♦', '⋅')
 
-GW.get_tile_map_height(env::Catcher) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::Catcher) = size(env.tile_map, 3)
+GW.get_height(env::Catcher) = size(env.tile_map, 2)
+GW.get_width(env::Catcher) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::Catcher, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/collect_gems_directed.jl
+++ b/src/envs/collect_gems_directed.jl
@@ -114,7 +114,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: CollectGe
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: CollectGemsDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: CollectGemsDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: CollectGemsDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: CollectGemsDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: CollectGemsDirected} = env.env.env.reward

--- a/src/envs/collect_gems_directed.jl
+++ b/src/envs/collect_gems_directed.jl
@@ -80,8 +80,8 @@ end
 
 CHARACTERS = ('☻', '█', '♦', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::CollectGemsDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::CollectGemsDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::CollectGemsDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::CollectGemsDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::CollectGemsDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/collect_gems_directed.jl
+++ b/src/envs/collect_gems_directed.jl
@@ -78,31 +78,57 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♦', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::CollectGemsDirected) = GW.get_height(env.env)
+GW.get_width(env::CollectGemsDirected) = GW.get_width(env.env)
 
-GW.get_height(env::CollectGemsDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::CollectGemsDirected) = size(env.env.tile_map, 3)
+GW.get_action_names(env::CollectGemsDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::CollectGemsDirected) = GW.get_object_names(env.env)
 
-function GW.get_pretty_tile_map(env::CollectGemsDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::CollectGemsDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♦', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+        return characters[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::CollectGemsDirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::CollectGemsDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+function GW.get_pretty_sub_tile_map(env::CollectGemsDirected, window_size, position::CartesianIndex{2})
+    tile_map = env.env.tile_map
+    agent_position = env.env.agent_position
+    agent_direction = env.agent_direction
+
+    characters = ('☻', '█', '♦', '→', '↑', '←', '↓', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    elseif object == AGENT
+        return '↓'
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::CollectGemsDirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.env.reward)\ndone: $(env.env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::CollectGemsDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/collect_gems_directed.jl
+++ b/src/envs/collect_gems_directed.jl
@@ -15,7 +15,7 @@ const WALL = CGUM.WALL
 const GEM = CGUM.GEM
 const NUM_ACTIONS = 4
 
-mutable struct CollectGemsDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct CollectGemsDirected{R, RNG} <: GW.AbstractGridWorld
     env::CGUM.CollectGemsUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/collect_gems_directed.jl
+++ b/src/envs/collect_gems_directed.jl
@@ -83,7 +83,7 @@ CHARACTERS = ('☻', '█', '♦', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::CollectGemsDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::CollectGemsDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::CollectGemsDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::CollectGemsDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -98,7 +98,7 @@ GW.get_action_keys(env::CollectGemsDirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::CollectGemsDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::CollectGemsDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
     print(io, str)
     return nothing

--- a/src/envs/collect_gems_multi_agent_undirected.jl
+++ b/src/envs/collect_gems_multi_agent_undirected.jl
@@ -151,7 +151,7 @@ end
 GW.get_height(env::CollectGemsMultiAgentUndirected) = size(env.tile_map, 2)
 GW.get_width(env::CollectGemsMultiAgentUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::CollectGemsMultiAgentUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::CollectGemsMultiAgentUndirected, i::Integer, j::Integer)
     tile_map = env.tile_map
     object = findfirst(@view tile_map[:, i, j])
     num_agents = size(tile_map, 1) - 2
@@ -171,7 +171,7 @@ GW.get_action_keys(env::CollectGemsMultiAgentUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::CollectGemsMultiAgentUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::CollectGemsMultiAgentUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)\ncurrent_agent = $(env.current_agent)"
     print(io, str)
     return nothing

--- a/src/envs/collect_gems_multi_agent_undirected.jl
+++ b/src/envs/collect_gems_multi_agent_undirected.jl
@@ -97,7 +97,7 @@ function GW.reset!(env::CollectGemsMultiAgentUndirected)
 end
 
 function GW.act!(env::CollectGemsMultiAgentUndirected, action)
-    @assert action in 1:NUM_ACTIONS "Invalid action $(action)"
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action)"
 
     tile_map = env.tile_map
     agent_positions = env.agent_positions
@@ -187,7 +187,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: CollectGe
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: CollectGemsMultiAgentUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: CollectGemsMultiAgentUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: CollectGemsMultiAgentUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: CollectGemsMultiAgentUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: CollectGemsMultiAgentUndirected} = env.env.reward

--- a/src/envs/collect_gems_multi_agent_undirected.jl
+++ b/src/envs/collect_gems_multi_agent_undirected.jl
@@ -148,8 +148,8 @@ end
 ##### miscellaneous
 #####
 
-GW.get_tile_map_height(env::CollectGemsMultiAgentUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::CollectGemsMultiAgentUndirected) = size(env.tile_map, 3)
+GW.get_height(env::CollectGemsMultiAgentUndirected) = size(env.tile_map, 2)
+GW.get_width(env::CollectGemsMultiAgentUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::CollectGemsMultiAgentUndirected, i::Integer, j::Integer)
     tile_map = env.tile_map

--- a/src/envs/collect_gems_multi_agent_undirected.jl
+++ b/src/envs/collect_gems_multi_agent_undirected.jl
@@ -10,7 +10,7 @@ import ReinforcementLearningBase as RLBase
 
 const NUM_ACTIONS = 4
 
-mutable struct CollectGemsMultiAgentUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct CollectGemsMultiAgentUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_positions::Vector{CartesianIndex{2}}
     current_agent::Int

--- a/src/envs/collect_gems_undirected.jl
+++ b/src/envs/collect_gems_undirected.jl
@@ -124,7 +124,7 @@ CHARACTERS = ('☻', '█', '♦', '⋅')
 GW.get_height(env::CollectGemsUndirected) = size(env.tile_map, 2)
 GW.get_width(env::CollectGemsUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::CollectGemsUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::CollectGemsUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -137,7 +137,7 @@ GW.get_action_keys(env::CollectGemsUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::CollectGemsUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::CollectGemsUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/collect_gems_undirected.jl
+++ b/src/envs/collect_gems_undirected.jl
@@ -121,8 +121,8 @@ end
 
 CHARACTERS = ('☻', '█', '♦', '⋅')
 
-GW.get_tile_map_height(env::CollectGemsUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::CollectGemsUndirected) = size(env.tile_map, 3)
+GW.get_height(env::CollectGemsUndirected) = size(env.tile_map, 2)
+GW.get_width(env::CollectGemsUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::CollectGemsUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/collect_gems_undirected.jl
+++ b/src/envs/collect_gems_undirected.jl
@@ -14,7 +14,7 @@ const WALL = 2
 const GEM = 3
 const NUM_ACTIONS = 4
 
-mutable struct CollectGemsUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct CollectGemsUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/collect_gems_undirected.jl
+++ b/src/envs/collect_gems_undirected.jl
@@ -153,7 +153,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: CollectGe
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: CollectGemsUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: CollectGemsUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: CollectGemsUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: CollectGemsUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: CollectGemsUndirected} = env.env.reward

--- a/src/envs/collect_gems_undirected.jl
+++ b/src/envs/collect_gems_undirected.jl
@@ -119,29 +119,52 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♦', '⋅')
-
 GW.get_height(env::CollectGemsUndirected) = size(env.tile_map, 2)
 GW.get_width(env::CollectGemsUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::CollectGemsUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::CollectGemsUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::CollectGemsUndirected) = (:AGENT, :WALL, :GEM)
+
+function GW.get_pretty_tile_map(env::CollectGemsUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♦', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::CollectGemsUndirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::CollectGemsUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+function GW.get_pretty_sub_tile_map(env::CollectGemsUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '♦', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::CollectGemsUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::CollectGemsUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/door_key_directed.jl
+++ b/src/envs/door_key_directed.jl
@@ -89,7 +89,7 @@ CHARACTERS = ('☻', '█', '♥', '▒', '⚷', '→', '↑', '←', '↓', '�
 GW.get_height(env::DoorKeyDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::DoorKeyDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::DoorKeyDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::DoorKeyDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -104,7 +104,7 @@ GW.get_action_keys(env::DoorKeyDirected) = ('w', 's', 'a', 'd', 'p')
 GW.get_action_names(env::DoorKeyDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT, :PICK_UP)
 
 function Base.show(io::IO, ::MIME"text/plain", env::DoorKeyDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
     print(io, str)
     return nothing

--- a/src/envs/door_key_directed.jl
+++ b/src/envs/door_key_directed.jl
@@ -84,31 +84,59 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '▒', '⚷', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::DoorKeyDirected) = GW.get_height(env.env)
+GW.get_width(env::DoorKeyDirected) = GW.get_width(env.env)
 
-GW.get_height(env::DoorKeyDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::DoorKeyDirected) = size(env.env.tile_map, 3)
+GW.get_action_names(env::DoorKeyDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT, :PICK_UP)
+GW.get_object_names(env::DoorKeyDirected) = GW.get_object_names(env.env)
 
-function GW.get_pretty_tile_map(env::DoorKeyDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::DoorKeyDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '▒', '⚷', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+        return characters[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::DoorKeyDirected) = ('w', 's', 'a', 'd', 'p')
-GW.get_action_names(env::DoorKeyDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT, :PICK_UP)
+function GW.get_pretty_sub_tile_map(env::DoorKeyDirected, window_size, position::CartesianIndex{2})
+    tile_map = env.env.tile_map
+    agent_position = env.env.agent_position
+    agent_direction = env.agent_direction
+
+    characters = ('☻', '█', '♥', '▒', '⚷', '→', '↑', '←', '↓', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    elseif object == AGENT
+        return '↓'
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::DoorKeyDirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\nhas_key: $(env.env.has_key)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::DoorKeyDirected) = ('w', 's', 'a', 'd', 'p')
 
 #####
 ##### RLBase API

--- a/src/envs/door_key_directed.jl
+++ b/src/envs/door_key_directed.jl
@@ -86,8 +86,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '▒', '⚷', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::DoorKeyDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::DoorKeyDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::DoorKeyDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::DoorKeyDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::DoorKeyDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/door_key_directed.jl
+++ b/src/envs/door_key_directed.jl
@@ -17,7 +17,7 @@ const DOOR = DKUM.DOOR
 const KEY = DKUM.KEY
 const NUM_ACTIONS = 5
 
-mutable struct DoorKeyDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct DoorKeyDirected{R, RNG} <: GW.AbstractGridWorld
     env::DKUM.DoorKeyUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/door_key_directed.jl
+++ b/src/envs/door_key_directed.jl
@@ -120,7 +120,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: DoorKeyDi
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: DoorKeyDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DoorKeyDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DoorKeyDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: DoorKeyDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: DoorKeyDirected} = env.env.env.reward

--- a/src/envs/door_key_undirected.jl
+++ b/src/envs/door_key_undirected.jl
@@ -180,29 +180,54 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '▒', '⚷', '⋅')
-
 GW.get_height(env::DoorKeyUndirected) = size(env.tile_map, 2)
 GW.get_width(env::DoorKeyUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::DoorKeyUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::DoorKeyUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT, :PICK_UP)
+GW.get_object_names(env::DoorKeyUndirected) = (:AGENT, :WALL, :GOAL, :DOOR, :KEY)
+
+function GW.get_pretty_tile_map(env::DoorKeyUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '▒', '⚷', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::DoorKeyUndirected) = ('w', 's', 'a', 'd', 'p')
-GW.get_action_names(env::DoorKeyUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT, :PICK_UP)
+function GW.get_pretty_sub_tile_map(env::DoorKeyUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '♥', '▒', '⚷', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::DoorKeyUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\nhas_key: $(env.has_key)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::DoorKeyUndirected) = ('w', 's', 'a', 'd', 'p')
 
 #####
 ##### RLBase API

--- a/src/envs/door_key_undirected.jl
+++ b/src/envs/door_key_undirected.jl
@@ -16,7 +16,7 @@ const DOOR = 4
 const KEY = 5
 const NUM_ACTIONS = 5
 
-mutable struct DoorKeyUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct DoorKeyUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/door_key_undirected.jl
+++ b/src/envs/door_key_undirected.jl
@@ -182,8 +182,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '▒', '⚷', '⋅')
 
-GW.get_tile_map_height(env::DoorKeyUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::DoorKeyUndirected) = size(env.tile_map, 3)
+GW.get_height(env::DoorKeyUndirected) = size(env.tile_map, 2)
+GW.get_width(env::DoorKeyUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::DoorKeyUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/door_key_undirected.jl
+++ b/src/envs/door_key_undirected.jl
@@ -185,7 +185,7 @@ CHARACTERS = ('☻', '█', '♥', '▒', '⚷', '⋅')
 GW.get_height(env::DoorKeyUndirected) = size(env.tile_map, 2)
 GW.get_width(env::DoorKeyUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::DoorKeyUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::DoorKeyUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -198,7 +198,7 @@ GW.get_action_keys(env::DoorKeyUndirected) = ('w', 's', 'a', 'd', 'p')
 GW.get_action_names(env::DoorKeyUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT, :PICK_UP)
 
 function Base.show(io::IO, ::MIME"text/plain", env::DoorKeyUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/door_key_undirected.jl
+++ b/src/envs/door_key_undirected.jl
@@ -214,7 +214,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: DoorKeyUn
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: DoorKeyUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DoorKeyUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DoorKeyUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: DoorKeyUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: DoorKeyUndirected} = env.env.reward

--- a/src/envs/dynamic_obstacles_directed.jl
+++ b/src/envs/dynamic_obstacles_directed.jl
@@ -84,8 +84,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '⊗', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::DynamicObstaclesDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::DynamicObstaclesDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::DynamicObstaclesDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::DynamicObstaclesDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::DynamicObstaclesDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/dynamic_obstacles_directed.jl
+++ b/src/envs/dynamic_obstacles_directed.jl
@@ -118,7 +118,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: DynamicOb
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: DynamicObstaclesDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesDirected} = env.env.env.reward

--- a/src/envs/dynamic_obstacles_directed.jl
+++ b/src/envs/dynamic_obstacles_directed.jl
@@ -87,7 +87,7 @@ CHARACTERS = ('☻', '█', '♥', '⊗', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::DynamicObstaclesDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::DynamicObstaclesDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::DynamicObstaclesDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::DynamicObstaclesDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -102,7 +102,7 @@ GW.get_action_keys(env::DynamicObstaclesDirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::DynamicObstaclesDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::DynamicObstaclesDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
     print(io, str)
     return nothing

--- a/src/envs/dynamic_obstacles_directed.jl
+++ b/src/envs/dynamic_obstacles_directed.jl
@@ -82,31 +82,58 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '⊗', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::DynamicObstaclesDirected) = GW.get_height(env.env)
+GW.get_width(env::DynamicObstaclesDirected) = GW.get_width(env.env)
 
-GW.get_height(env::DynamicObstaclesDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::DynamicObstaclesDirected) = size(env.env.tile_map, 3)
+GW.get_action_names(env::DynamicObstaclesDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::DynamicObstaclesDirected) = GW.get_object_names(env.env)
 
-function GW.get_pretty_tile_map(env::DynamicObstaclesDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::DynamicObstaclesDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '⊗', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+        return characters[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::DynamicObstaclesDirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::DynamicObstaclesDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+function GW.get_pretty_sub_tile_map(env::DynamicObstaclesDirected, window_size, position::CartesianIndex{2})
+    tile_map = env.env.tile_map
+    agent_position = env.env.agent_position
+    agent_direction = env.agent_direction
+
+    characters = ('☻', '█', '♥', '⊗', '→', '↑', '←', '↓', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    elseif object == AGENT
+        return '↓'
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::DynamicObstaclesDirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::DynamicObstaclesDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/dynamic_obstacles_directed.jl
+++ b/src/envs/dynamic_obstacles_directed.jl
@@ -16,7 +16,7 @@ const GOAL = DOUM.GOAL
 const OBSTACLE = DOUM.OBSTACLE
 const NUM_ACTIONS = 4
 
-mutable struct DynamicObstaclesDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct DynamicObstaclesDirected{R, RNG} <: GW.AbstractGridWorld
     env::DOUM.DynamicObstaclesUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/dynamic_obstacles_undirected.jl
+++ b/src/envs/dynamic_obstacles_undirected.jl
@@ -148,29 +148,53 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '⊗', '⋅')
-
 GW.get_height(env::DynamicObstaclesUndirected) = size(env.tile_map, 2)
 GW.get_width(env::DynamicObstaclesUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::DynamicObstaclesUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::DynamicObstaclesUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::DynamicObstaclesUndirected) = (:AGENT, :WALL, :GOAL, :OBSTACLE)
+
+function GW.get_pretty_tile_map(env::DynamicObstaclesUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '⊗', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::DynamicObstaclesUndirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::DynamicObstaclesUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+function GW.get_pretty_sub_tile_map(env::DynamicObstaclesUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '♥', '⊗', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::DynamicObstaclesUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::DynamicObstaclesUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### DynamicObstaclesUndirected

--- a/src/envs/dynamic_obstacles_undirected.jl
+++ b/src/envs/dynamic_obstacles_undirected.jl
@@ -150,8 +150,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '⊗', '⋅')
 
-GW.get_tile_map_height(env::DynamicObstaclesUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::DynamicObstaclesUndirected) = size(env.tile_map, 3)
+GW.get_height(env::DynamicObstaclesUndirected) = size(env.tile_map, 2)
+GW.get_width(env::DynamicObstaclesUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::DynamicObstaclesUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/dynamic_obstacles_undirected.jl
+++ b/src/envs/dynamic_obstacles_undirected.jl
@@ -153,7 +153,7 @@ CHARACTERS = ('☻', '█', '♥', '⊗', '⋅')
 GW.get_height(env::DynamicObstaclesUndirected) = size(env.tile_map, 2)
 GW.get_width(env::DynamicObstaclesUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::DynamicObstaclesUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::DynamicObstaclesUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -166,7 +166,7 @@ GW.get_action_keys(env::DynamicObstaclesUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::DynamicObstaclesUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::DynamicObstaclesUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/dynamic_obstacles_undirected.jl
+++ b/src/envs/dynamic_obstacles_undirected.jl
@@ -182,7 +182,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: DynamicOb
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: DynamicObstaclesUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: DynamicObstaclesUndirected} = env.env.reward

--- a/src/envs/dynamic_obstacles_undirected.jl
+++ b/src/envs/dynamic_obstacles_undirected.jl
@@ -15,7 +15,7 @@ const GOAL = 3
 const OBSTACLE = 4
 const NUM_ACTIONS = 4
 
-mutable struct DynamicObstaclesUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct DynamicObstaclesUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/go_to_target_directed.jl
+++ b/src/envs/go_to_target_directed.jl
@@ -83,31 +83,62 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '✖', '♦', '→', '↑', '←', '↓', '⋅')
 
-GW.get_height(env::GoToTargetDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::GoToTargetDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::GoToTargetDirected) = GW.get_height(env.env)
+GW.get_width(env::GoToTargetDirected) = GW.get_width(env.env)
 
-function GW.get_pretty_tile_map(env::GoToTargetDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+GW.get_action_names(env::GoToTargetDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::GoToTargetDirected) = GW.get_object_names(env.env)
+
+function GW.get_pretty_tile_map(env::GoToTargetDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '✖', '♦', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+        return characters[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::GoToTargetDirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::GoToTargetDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+function GW.get_pretty_sub_tile_map(env::GoToTargetDirected, window_size, position::CartesianIndex{2})
+    tile_map = env.env.tile_map
+    agent_position = env.env.agent_position
+    agent_direction = env.agent_direction
+
+    characters = ('☻', '█', '✖', '♦', '→', '↑', '←', '↓', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    elseif object == AGENT
+        return '↓'
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::GoToTargetDirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)\ntarget = $(env.env.target) ($(CHARACTERS[2 + env.env.target]))"
+    characters = ('☻', '█', '✖', '♦', '→', '↑', '←', '↓', '⋅')
+
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\ntarget = $(env.env.target) ($(characters[2 + env.env.target]))"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::GoToTargetDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/go_to_target_directed.jl
+++ b/src/envs/go_to_target_directed.jl
@@ -16,7 +16,7 @@ const TARGET1 = GTTUM.TARGET1
 const TARGET2 = GTTUM.TARGET2
 const NUM_ACTIONS = 4
 
-mutable struct GoToTargetDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct GoToTargetDirected{R, RNG} <: GW.AbstractGridWorld
     env::GTTUM.GoToTargetUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/go_to_target_directed.jl
+++ b/src/envs/go_to_target_directed.jl
@@ -85,8 +85,8 @@ end
 
 CHARACTERS = ('☻', '█', '✖', '♦', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::GoToTargetDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::GoToTargetDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::GoToTargetDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::GoToTargetDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::GoToTargetDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/go_to_target_directed.jl
+++ b/src/envs/go_to_target_directed.jl
@@ -119,7 +119,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: GoToTarge
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: GoToTargetDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GoToTargetDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GoToTargetDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: GoToTargetDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: GoToTargetDirected} = env.env.env.reward

--- a/src/envs/go_to_target_directed.jl
+++ b/src/envs/go_to_target_directed.jl
@@ -88,7 +88,7 @@ CHARACTERS = ('☻', '█', '✖', '♦', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::GoToTargetDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::GoToTargetDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::GoToTargetDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::GoToTargetDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -103,7 +103,7 @@ GW.get_action_keys(env::GoToTargetDirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::GoToTargetDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::GoToTargetDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)\ntarget = $(env.env.target) ($(CHARACTERS[2 + env.env.target]))"
     print(io, str)
     return nothing

--- a/src/envs/go_to_target_undirected.jl
+++ b/src/envs/go_to_target_undirected.jl
@@ -15,7 +15,7 @@ const TARGET1 = 3
 const TARGET2 = 4
 const NUM_ACTIONS = 4
 
-mutable struct GoToTargetUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct GoToTargetUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/go_to_target_undirected.jl
+++ b/src/envs/go_to_target_undirected.jl
@@ -160,7 +160,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: GoToTarge
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: GoToTargetUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GoToTargetUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GoToTargetUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: GoToTargetUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: GoToTargetUndirected} = env.env.reward

--- a/src/envs/go_to_target_undirected.jl
+++ b/src/envs/go_to_target_undirected.jl
@@ -128,8 +128,8 @@ end
 
 CHARACTERS = ('☻', '█', '✖', '♦', '⋅')
 
-GW.get_tile_map_height(env::GoToTargetUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::GoToTargetUndirected) = size(env.tile_map, 3)
+GW.get_height(env::GoToTargetUndirected) = size(env.tile_map, 2)
+GW.get_width(env::GoToTargetUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::GoToTargetUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/go_to_target_undirected.jl
+++ b/src/envs/go_to_target_undirected.jl
@@ -131,7 +131,7 @@ CHARACTERS = ('☻', '█', '✖', '♦', '⋅')
 GW.get_height(env::GoToTargetUndirected) = size(env.tile_map, 2)
 GW.get_width(env::GoToTargetUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::GoToTargetUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::GoToTargetUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -144,7 +144,7 @@ GW.get_action_keys(env::GoToTargetUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::GoToTargetUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::GoToTargetUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)\ntarget = $(env.target) ($(CHARACTERS[2 + env.target]))"
     print(io, str)
     return nothing

--- a/src/envs/go_to_target_undirected.jl
+++ b/src/envs/go_to_target_undirected.jl
@@ -126,29 +126,56 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '✖', '♦', '⋅')
-
 GW.get_height(env::GoToTargetUndirected) = size(env.tile_map, 2)
 GW.get_width(env::GoToTargetUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::GoToTargetUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::GoToTargetUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::GoToTargetUndirected) = (:AGENT, :WALL, :TARGET1, :TARGET2)
+
+function GW.get_pretty_tile_map(env::GoToTargetUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '✖', '♦', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::GoToTargetUndirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::GoToTargetUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+function GW.get_pretty_sub_tile_map(env::GoToTargetUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '✖', '♦', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::GoToTargetUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)\ntarget = $(env.target) ($(CHARACTERS[2 + env.target]))"
+    characters = ('☻', '█', '✖', '♦', '⋅')
+
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\ntarget = $(env.target) ($(characters[2 + env.target]))"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::GoToTargetUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/grid_rooms_directed.jl
+++ b/src/envs/grid_rooms_directed.jl
@@ -113,7 +113,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: GridRooms
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: GridRoomsDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GridRoomsDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GridRoomsDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: GridRoomsDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: GridRoomsDirected} = env.env.env.reward

--- a/src/envs/grid_rooms_directed.jl
+++ b/src/envs/grid_rooms_directed.jl
@@ -15,7 +15,7 @@ const WALL = GRUM.WALL
 const GOAL = GRUM.GOAL
 const NUM_ACTIONS = 4
 
-mutable struct GridRoomsDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct GridRoomsDirected{R, RNG} <: GW.AbstractGridWorld
     env::GRUM.GridRoomsUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/grid_rooms_directed.jl
+++ b/src/envs/grid_rooms_directed.jl
@@ -77,31 +77,58 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::GridRoomsDirected) = GW.get_height(env.env)
+GW.get_width(env::GridRoomsDirected) = GW.get_width(env.env)
 
-GW.get_height(env::GridRoomsDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::GridRoomsDirected) = size(env.env.tile_map, 3)
+GW.get_action_names(env::GridRoomsDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::GridRoomsDirected) = GW.get_object_names(env.env)
 
-function GW.get_pretty_tile_map(env::GridRoomsDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::GridRoomsDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+        return characters[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::GridRoomsDirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::GridRoomsDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+function GW.get_pretty_sub_tile_map(env::GridRoomsDirected, window_size, position::CartesianIndex{2})
+    tile_map = env.env.tile_map
+    agent_position = env.env.agent_position
+    agent_direction = env.agent_direction
+
+    characters = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    elseif object == AGENT
+        return '↓'
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::GridRoomsDirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::GridRoomsDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/grid_rooms_directed.jl
+++ b/src/envs/grid_rooms_directed.jl
@@ -82,7 +82,7 @@ CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::GridRoomsDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::GridRoomsDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::GridRoomsDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::GridRoomsDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -97,7 +97,7 @@ GW.get_action_keys(env::GridRoomsDirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::GridRoomsDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::GridRoomsDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
     print(io, str)
     return nothing

--- a/src/envs/grid_rooms_directed.jl
+++ b/src/envs/grid_rooms_directed.jl
@@ -79,8 +79,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::GridRoomsDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::GridRoomsDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::GridRoomsDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::GridRoomsDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::GridRoomsDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/grid_rooms_undirected.jl
+++ b/src/envs/grid_rooms_undirected.jl
@@ -162,7 +162,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: GridRooms
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: GridRoomsUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GridRoomsUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: GridRoomsUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: GridRoomsUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: GridRoomsUndirected} = env.env.reward

--- a/src/envs/grid_rooms_undirected.jl
+++ b/src/envs/grid_rooms_undirected.jl
@@ -128,29 +128,53 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '⋅')
-
 GW.get_height(env::GridRoomsUndirected) = size(env.tile_map, 2)
 GW.get_width(env::GridRoomsUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::GridRoomsUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::GridRoomsUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::GridRoomsUndirected) = (:AGENT, :WALL, :GOAL)
+
+function GW.get_pretty_tile_map(env::GridRoomsUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::GridRoomsUndirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::GridRoomsUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+function GW.get_pretty_sub_tile_map(env::GridRoomsUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '♥', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::GridRoomsUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::GridRoomsUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/grid_rooms_undirected.jl
+++ b/src/envs/grid_rooms_undirected.jl
@@ -14,7 +14,7 @@ const WALL = 2
 const GOAL = 3
 const NUM_ACTIONS = 4
 
-mutable struct GridRoomsUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct GridRoomsUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/grid_rooms_undirected.jl
+++ b/src/envs/grid_rooms_undirected.jl
@@ -133,7 +133,7 @@ CHARACTERS = ('☻', '█', '♥', '⋅')
 GW.get_height(env::GridRoomsUndirected) = size(env.tile_map, 2)
 GW.get_width(env::GridRoomsUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::GridRoomsUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::GridRoomsUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -146,7 +146,7 @@ GW.get_action_keys(env::GridRoomsUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::GridRoomsUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::GridRoomsUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/grid_rooms_undirected.jl
+++ b/src/envs/grid_rooms_undirected.jl
@@ -130,8 +130,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '⋅')
 
-GW.get_tile_map_height(env::GridRoomsUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::GridRoomsUndirected) = size(env.tile_map, 3)
+GW.get_height(env::GridRoomsUndirected) = size(env.tile_map, 2)
+GW.get_width(env::GridRoomsUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::GridRoomsUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/maze_directed.jl
+++ b/src/envs/maze_directed.jl
@@ -79,8 +79,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::MazeDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::MazeDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::MazeDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::MazeDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::MazeDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/maze_directed.jl
+++ b/src/envs/maze_directed.jl
@@ -82,7 +82,7 @@ CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::MazeDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::MazeDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::MazeDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::MazeDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -97,7 +97,7 @@ GW.get_action_keys(env::MazeDirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::MazeDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::MazeDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
     print(io, str)
     return nothing

--- a/src/envs/maze_directed.jl
+++ b/src/envs/maze_directed.jl
@@ -113,7 +113,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: MazeDirec
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: MazeDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: MazeDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: MazeDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: MazeDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: MazeDirected} = env.env.env.reward

--- a/src/envs/maze_directed.jl
+++ b/src/envs/maze_directed.jl
@@ -15,7 +15,7 @@ const WALL = MUM.WALL
 const GOAL = MUM.GOAL
 const NUM_ACTIONS = 4
 
-mutable struct MazeDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct MazeDirected{R, RNG} <: GW.AbstractGridWorld
     env::MUM.MazeUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/maze_directed.jl
+++ b/src/envs/maze_directed.jl
@@ -77,31 +77,58 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::MazeDirected) = GW.get_height(env.env)
+GW.get_width(env::MazeDirected) = GW.get_width(env.env)
 
-GW.get_height(env::MazeDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::MazeDirected) = size(env.env.tile_map, 3)
+GW.get_action_names(env::MazeDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::MazeDirected) = GW.get_object_names(env.env)
 
-function GW.get_pretty_tile_map(env::MazeDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::MazeDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+        return characters[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::MazeDirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::MazeDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+function GW.get_pretty_sub_tile_map(env::MazeDirected, window_size, position::CartesianIndex{2})
+    tile_map = env.env.tile_map
+    agent_position = env.env.agent_position
+    agent_direction = env.agent_direction
+
+    characters = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    elseif object == AGENT
+        return '↓'
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::MazeDirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::MazeDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/maze_undirected.jl
+++ b/src/envs/maze_undirected.jl
@@ -198,7 +198,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: MazeUndir
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: MazeUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: MazeUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: MazeUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: MazeUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: MazeUndirected} = env.env.reward

--- a/src/envs/maze_undirected.jl
+++ b/src/envs/maze_undirected.jl
@@ -14,7 +14,7 @@ const WALL = 2
 const GOAL = 3
 const NUM_ACTIONS = 4
 
-mutable struct MazeUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct MazeUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/maze_undirected.jl
+++ b/src/envs/maze_undirected.jl
@@ -169,7 +169,7 @@ CHARACTERS = ('☻', '█', '♥', '⋅')
 GW.get_height(env::MazeUndirected) = size(env.tile_map, 2)
 GW.get_width(env::MazeUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::MazeUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::MazeUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -182,7 +182,7 @@ GW.get_action_keys(env::MazeUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::MazeUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::MazeUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/maze_undirected.jl
+++ b/src/envs/maze_undirected.jl
@@ -164,29 +164,53 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '⋅')
-
 GW.get_height(env::MazeUndirected) = size(env.tile_map, 2)
 GW.get_width(env::MazeUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::MazeUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::MazeUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::MazeUndirected) = (:AGENT, :WALL, :GOAL)
+
+function GW.get_pretty_tile_map(env::MazeUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::MazeUndirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::MazeUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+function GW.get_pretty_sub_tile_map(env::MazeUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '♥', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::MazeUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::MazeUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/maze_undirected.jl
+++ b/src/envs/maze_undirected.jl
@@ -166,8 +166,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '⋅')
 
-GW.get_tile_map_height(env::MazeUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::MazeUndirected) = size(env.tile_map, 3)
+GW.get_height(env::MazeUndirected) = size(env.tile_map, 2)
+GW.get_width(env::MazeUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::MazeUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/sequential_rooms_directed.jl
+++ b/src/envs/sequential_rooms_directed.jl
@@ -77,42 +77,31 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::SequentialRoomsDirected) = GW.get_height(env.env)
+GW.get_width(env::SequentialRoomsDirected) = GW.get_width(env.env)
 
-GW.get_height(env::SequentialRoomsDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::SequentialRoomsDirected) = size(env.env.tile_map, 3)
-
-function GW.get_pretty_tile_map(env::SequentialRoomsDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
-    if isnothing(object)
-        return CHARACTERS[end]
-    elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
-    else
-        return CHARACTERS[object]
-    end
-end
-
-GW.get_action_keys(env::SequentialRoomsDirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::SequentialRoomsDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::SequentialRoomsDirected) = GW.get_object_names(env.env)
 
 function Base.show(io::IO, ::MIME"text/plain", env::SequentialRoomsDirected)
     tile_map = env.env.tile_map
     small_tile_map = SRUM.get_small_tile_map(tile_map)
 
+    characters = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+
     _, height_small_tile_map, width_small_tile_map = size(small_tile_map)
 
-    str = ""
+    str = "tile_map:\n"
 
     for i in 1:height_small_tile_map
         for j in 1:width_small_tile_map
             object = findfirst(@view small_tile_map[:, i, j])
             if isnothing(object)
-                char = CHARACTERS[end]
+                char = characters[end]
             elseif object == AGENT
-                char = CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+                char = characters[NUM_OBJECTS + 1 + env.agent_direction]
             else
-                char = CHARACTERS[object]
+                char = characters[object]
             end
             str = str * char
         end
@@ -122,10 +111,15 @@ function Base.show(io::IO, ::MIME"text/plain", env::SequentialRoomsDirected)
         end
     end
 
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::SequentialRoomsDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/sequential_rooms_directed.jl
+++ b/src/envs/sequential_rooms_directed.jl
@@ -137,7 +137,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: Sequentia
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: SequentialRoomsDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsDirected} = env.env.env.reward

--- a/src/envs/sequential_rooms_directed.jl
+++ b/src/envs/sequential_rooms_directed.jl
@@ -79,8 +79,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::SequentialRoomsDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::SequentialRoomsDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::SequentialRoomsDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::SequentialRoomsDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::SequentialRoomsDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/sequential_rooms_directed.jl
+++ b/src/envs/sequential_rooms_directed.jl
@@ -15,7 +15,7 @@ const WALL = SRUM.WALL
 const GOAL = SRUM.GOAL
 const NUM_ACTIONS = 4
 
-mutable struct SequentialRoomsDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct SequentialRoomsDirected{R, RNG} <: GW.AbstractGridWorld
     env::SRUM.SequentialRoomsUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/sequential_rooms_directed.jl
+++ b/src/envs/sequential_rooms_directed.jl
@@ -82,7 +82,7 @@ CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::SequentialRoomsDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::SequentialRoomsDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::SequentialRoomsDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::SequentialRoomsDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]

--- a/src/envs/sequential_rooms_undirected.jl
+++ b/src/envs/sequential_rooms_undirected.jl
@@ -350,7 +350,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: Sequentia
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: SequentialRoomsUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: SequentialRoomsUndirected} = env.env.reward

--- a/src/envs/sequential_rooms_undirected.jl
+++ b/src/envs/sequential_rooms_undirected.jl
@@ -20,7 +20,7 @@ end
 
 Room(top_left, height, width) = Room(CartesianIndices((top_left.I[1] : top_left.I[1] + height - 1, top_left.I[2] : top_left.I[2] + width - 1)))
 
-mutable struct SequentialRoomsUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct SequentialRoomsUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/sequential_rooms_undirected.jl
+++ b/src/envs/sequential_rooms_undirected.jl
@@ -294,38 +294,29 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '⋅')
-
 GW.get_height(env::SequentialRoomsUndirected) = size(env.tile_map, 2)
 GW.get_width(env::SequentialRoomsUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::SequentialRoomsUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
-    if isnothing(object)
-        return CHARACTERS[end]
-    else
-        return CHARACTERS[object]
-    end
-end
-
-GW.get_action_keys(env::SequentialRoomsUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::SequentialRoomsUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::SequentialRoomsUndirected) = (:AGENT, :WALL, :GOAL)
 
 function Base.show(io::IO, ::MIME"text/plain", env::SequentialRoomsUndirected)
     tile_map = env.tile_map
     small_tile_map = get_small_tile_map(tile_map)
 
+    characters = ('☻', '█', '♥', '⋅')
+
     _, height_small_tile_map, width_small_tile_map = size(small_tile_map)
 
-    str = ""
+    str = "tile_map:\n"
 
     for i in 1:height_small_tile_map
         for j in 1:width_small_tile_map
             object = findfirst(small_tile_map[:, i, j])
             if isnothing(object)
-                char = CHARACTERS[end]
+                char = characters[end]
             else
-                char = CHARACTERS[object]
+                char = characters[object]
             end
             str = str * char
         end
@@ -335,10 +326,15 @@ function Base.show(io::IO, ::MIME"text/plain", env::SequentialRoomsUndirected)
         end
     end
 
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::SequentialRoomsUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/sequential_rooms_undirected.jl
+++ b/src/envs/sequential_rooms_undirected.jl
@@ -299,7 +299,7 @@ CHARACTERS = ('☻', '█', '♥', '⋅')
 GW.get_height(env::SequentialRoomsUndirected) = size(env.tile_map, 2)
 GW.get_width(env::SequentialRoomsUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::SequentialRoomsUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::SequentialRoomsUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]

--- a/src/envs/sequential_rooms_undirected.jl
+++ b/src/envs/sequential_rooms_undirected.jl
@@ -296,8 +296,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '⋅')
 
-GW.get_tile_map_height(env::SequentialRoomsUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::SequentialRoomsUndirected) = size(env.tile_map, 3)
+GW.get_height(env::SequentialRoomsUndirected) = size(env.tile_map, 2)
+GW.get_width(env::SequentialRoomsUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::SequentialRoomsUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/single_room_directed.jl
+++ b/src/envs/single_room_directed.jl
@@ -15,7 +15,7 @@ const WALL = SRUM.WALL
 const GOAL = SRUM.GOAL
 const NUM_ACTIONS = 4
 
-mutable struct SingleRoomDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct SingleRoomDirected{R, RNG} <: GW.AbstractGridWorld
     env::SRUM.SingleRoomUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/single_room_directed.jl
+++ b/src/envs/single_room_directed.jl
@@ -93,7 +93,7 @@ function GW.get_pretty_tile_map(env::SingleRoomDirected, i::Integer, j::Integer)
     end
 end
 
-function GW.get_sub_tile_map_pretty_repr(env::SingleRoomDirected, window_size, position::CartesianIndex{2})
+function GW.get_pretty_sub_tile_map(env::SingleRoomDirected, window_size, position::CartesianIndex{2})
     tile_map = env.env.tile_map
     agent_position = env.env.agent_position
     agent_direction = env.agent_direction
@@ -117,7 +117,7 @@ function Base.show(io::IO, ::MIME"text/plain", env::SingleRoomDirected)
     str = "tile_map:\n"
     str = str * GW.get_pretty_tile_map(env)
     str = str * "\nsub_tile_map:\n"
-    str = str * GW.get_sub_tile_map_pretty_repr(env, GW.get_window_size(env))
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
     print(io, str)
     return nothing

--- a/src/envs/single_room_directed.jl
+++ b/src/envs/single_room_directed.jl
@@ -77,19 +77,22 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::SingleRoomDirected) = GW.get_height(env.env)
+GW.get_width(env::SingleRoomDirected) = GW.get_width(env.env)
 
-GW.get_height(env::SingleRoomDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::SingleRoomDirected) = size(env.env.tile_map, 3)
+GW.get_action_names(env::SingleRoomDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::SingleRoomDirected) = GW.get_object_names(env.env)
 
-function GW.get_pretty_tile_map(env::SingleRoomDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::SingleRoomDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
-        return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
+        return characters[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
@@ -98,30 +101,34 @@ function GW.get_pretty_sub_tile_map(env::SingleRoomDirected, window_size, positi
     agent_position = env.env.agent_position
     agent_direction = env.agent_direction
 
+    characters = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
+
     sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
 
     object = findfirst(@view sub_tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
         return '↓'
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
-
-GW.get_action_keys(env::SingleRoomDirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::SingleRoomDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::SingleRoomDirected)
     str = "tile_map:\n"
     str = str * GW.get_pretty_tile_map(env)
     str = str * "\nsub_tile_map:\n"
     str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::SingleRoomDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/single_room_directed.jl
+++ b/src/envs/single_room_directed.jl
@@ -82,7 +82,7 @@ CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::SingleRoomDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::SingleRoomDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::SingleRoomDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::SingleRoomDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -115,7 +115,7 @@ GW.get_action_names(env::SingleRoomDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :
 
 function Base.show(io::IO, ::MIME"text/plain", env::SingleRoomDirected)
     str = "tile_map:\n"
-    str = str * GW.get_tile_map_pretty_repr(env)
+    str = str * GW.get_pretty_tile_map(env)
     str = str * "\nsub_tile_map:\n"
     str = str * GW.get_sub_tile_map_pretty_repr(env, GW.get_window_size(env))
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)"

--- a/src/envs/single_room_directed.jl
+++ b/src/envs/single_room_directed.jl
@@ -79,8 +79,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::SingleRoomDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::SingleRoomDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::SingleRoomDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::SingleRoomDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::SingleRoomDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/single_room_directed.jl
+++ b/src/envs/single_room_directed.jl
@@ -133,7 +133,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: SingleRoo
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: SingleRoomDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SingleRoomDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SingleRoomDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: SingleRoomDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: SingleRoomDirected} = env.env.env.reward

--- a/src/envs/single_room_undirected.jl
+++ b/src/envs/single_room_undirected.jl
@@ -14,7 +14,7 @@ const WALL = 2
 const GOAL = 3
 const NUM_ACTIONS = 4
 
-mutable struct SingleRoomUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct SingleRoomUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/single_room_undirected.jl
+++ b/src/envs/single_room_undirected.jl
@@ -114,7 +114,7 @@ CHARACTERS = ('☻', '█', '♥', '⋅')
 GW.get_height(env::SingleRoomUndirected) = size(env.tile_map, 2)
 GW.get_width(env::SingleRoomUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::SingleRoomUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::SingleRoomUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -142,7 +142,7 @@ GW.get_action_names(env::SingleRoomUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LE
 
 function Base.show(io::IO, ::MIME"text/plain", env::SingleRoomUndirected)
     str = "tile_map:\n"
-    str = str * GW.get_tile_map_pretty_repr(env)
+    str = str * GW.get_pretty_tile_map(env)
     str = str * "\nsub_tile_map:\n"
     str = str * GW.get_sub_tile_map_pretty_repr(env, GW.get_window_size(env))
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"

--- a/src/envs/single_room_undirected.jl
+++ b/src/envs/single_room_undirected.jl
@@ -123,7 +123,7 @@ function GW.get_pretty_tile_map(env::SingleRoomUndirected, i::Integer, j::Intege
     end
 end
 
-function GW.get_sub_tile_map_pretty_repr(env::SingleRoomUndirected, window_size, position::CartesianIndex{2})
+function GW.get_pretty_sub_tile_map(env::SingleRoomUndirected, window_size, position::CartesianIndex{2})
     tile_map = env.tile_map
     agent_position = env.agent_position
 
@@ -144,7 +144,7 @@ function Base.show(io::IO, ::MIME"text/plain", env::SingleRoomUndirected)
     str = "tile_map:\n"
     str = str * GW.get_pretty_tile_map(env)
     str = str * "\nsub_tile_map:\n"
-    str = str * GW.get_sub_tile_map_pretty_repr(env, GW.get_window_size(env))
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/single_room_undirected.jl
+++ b/src/envs/single_room_undirected.jl
@@ -109,17 +109,20 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♥', '⋅')
-
 GW.get_height(env::SingleRoomUndirected) = size(env.tile_map, 2)
 GW.get_width(env::SingleRoomUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::SingleRoomUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::SingleRoomUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::SingleRoomUndirected) = (:AGENT, :WALL, :GOAL)
+
+function GW.get_pretty_tile_map(env::SingleRoomUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♥', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
@@ -127,28 +130,32 @@ function GW.get_pretty_sub_tile_map(env::SingleRoomUndirected, window_size, posi
     tile_map = env.tile_map
     agent_position = env.agent_position
 
+    characters = ('☻', '█', '♥', '⋅')
+
     sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
 
     object = findfirst(@view sub_tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
-
-GW.get_action_keys(env::SingleRoomUndirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::SingleRoomUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::SingleRoomUndirected)
     str = "tile_map:\n"
     str = str * GW.get_pretty_tile_map(env)
     str = str * "\nsub_tile_map:\n"
     str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::SingleRoomUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/single_room_undirected.jl
+++ b/src/envs/single_room_undirected.jl
@@ -111,8 +111,8 @@ end
 
 CHARACTERS = ('☻', '█', '♥', '⋅')
 
-GW.get_tile_map_height(env::SingleRoomUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::SingleRoomUndirected) = size(env.tile_map, 3)
+GW.get_height(env::SingleRoomUndirected) = size(env.tile_map, 2)
+GW.get_width(env::SingleRoomUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::SingleRoomUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/single_room_undirected.jl
+++ b/src/envs/single_room_undirected.jl
@@ -160,7 +160,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: SingleRoo
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: SingleRoomUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SingleRoomUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SingleRoomUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: SingleRoomUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: SingleRoomUndirected} = env.env.reward

--- a/src/envs/snake.jl
+++ b/src/envs/snake.jl
@@ -152,29 +152,53 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '∘', '♦', '⋅')
-
 GW.get_height(env::Snake) = size(env.tile_map, 2)
 GW.get_width(env::Snake) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::Snake, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::Snake) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::Snake) = (:AGENT, :WALL, :BODY, :FOOD)
+
+function GW.get_pretty_tile_map(env::Snake, position::CartesianIndex{2})
+    characters = ('☻', '█', '∘', '♦', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::Snake) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::Snake) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+function GW.get_pretty_sub_tile_map(env::Snake, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '∘', '♦', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::Snake)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::Snake) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/snake.jl
+++ b/src/envs/snake.jl
@@ -154,8 +154,8 @@ end
 
 CHARACTERS = ('☻', '█', '∘', '♦', '⋅')
 
-GW.get_tile_map_height(env::Snake) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::Snake) = size(env.tile_map, 3)
+GW.get_height(env::Snake) = size(env.tile_map, 2)
+GW.get_width(env::Snake) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::Snake, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/snake.jl
+++ b/src/envs/snake.jl
@@ -186,7 +186,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.Observation) where {E <: Snake} = en
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: Snake} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: Snake} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: Snake} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: Snake} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: Snake} = env.env.reward

--- a/src/envs/snake.jl
+++ b/src/envs/snake.jl
@@ -157,7 +157,7 @@ CHARACTERS = ('☻', '█', '∘', '♦', '⋅')
 GW.get_height(env::Snake) = size(env.tile_map, 2)
 GW.get_width(env::Snake) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::Snake, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::Snake, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -170,7 +170,7 @@ GW.get_action_keys(env::Snake) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::Snake) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::Snake)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)"
     print(io, str)
     return nothing

--- a/src/envs/snake.jl
+++ b/src/envs/snake.jl
@@ -16,7 +16,7 @@ const BODY = 3
 const FOOD = 4
 const NUM_ACTIONS = 4
 
-mutable struct Snake{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct Snake{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/sokoban/sokoban_directed.jl
+++ b/src/envs/sokoban/sokoban_directed.jl
@@ -92,31 +92,59 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '▒', '✖', '→', '↑', '←', '↓', '⋅')
+GW.get_height(env::SokobanDirected) = GW.get_height(env.env)
+GW.get_width(env::SokobanDirected) = GW.get_width(env.env)
 
-GW.get_height(env::SokobanDirected) = size(env.env.tile_map, 2)
-GW.get_width(env::SokobanDirected) = size(env.env.tile_map, 3)
+GW.get_action_names(env::SokobanDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+GW.get_object_names(env::SokobanDirected) = GW.get_object_names(env.env)
 
-function GW.get_pretty_tile_map(env::SokobanDirected, i::Integer, j::Integer)
-    object = findfirst(@view env.env.tile_map[:, i, j])
+function GW.get_pretty_tile_map(env::SokobanDirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '▒', '✖', '→', '↑', '←', '↓', '⋅')
+
+    object = findfirst(@view env.env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     elseif object == AGENT
         return CHARACTERS[NUM_OBJECTS + 1 + env.agent_direction]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::SokobanDirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::SokobanDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
+function GW.get_pretty_sub_tile_map(env::SokobanDirected, window_size, position::CartesianIndex{2})
+    tile_map = env.env.tile_map
+    agent_position = env.env.agent_position
+    agent_direction = env.agent_direction
+
+    characters = ('☻', '█', '▒', '✖', '→', '↑', '←', '↓', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size, agent_direction)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    elseif object == AGENT
+        return '↓'
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::SokobanDirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)\nlevel_number = $(env.env.level_number)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.env.reward)"
+    str = str * "\ndone: $(env.env.done)"
+    str = str * "\nlevel_number: $(env.env.level_number)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::SokobanDirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/sokoban/sokoban_directed.jl
+++ b/src/envs/sokoban/sokoban_directed.jl
@@ -94,8 +94,8 @@ end
 
 CHARACTERS = ('☻', '█', '▒', '✖', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::SokobanDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::SokobanDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::SokobanDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::SokobanDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::SokobanDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/sokoban/sokoban_directed.jl
+++ b/src/envs/sokoban/sokoban_directed.jl
@@ -16,7 +16,7 @@ const BOX = SUM.BOX
 const TARGET = SUM.TARGET
 const NUM_ACTIONS = 4
 
-mutable struct SokobanDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct SokobanDirected{R, RNG} <: GW.AbstractGridWorld
     env::SUM.SokobanUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/sokoban/sokoban_directed.jl
+++ b/src/envs/sokoban/sokoban_directed.jl
@@ -128,7 +128,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: SokobanDi
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: SokobanDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SokobanDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SokobanDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: SokobanDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: SokobanDirected} = env.env.env.reward

--- a/src/envs/sokoban/sokoban_directed.jl
+++ b/src/envs/sokoban/sokoban_directed.jl
@@ -97,7 +97,7 @@ CHARACTERS = ('☻', '█', '▒', '✖', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::SokobanDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::SokobanDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::SokobanDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::SokobanDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -112,7 +112,7 @@ GW.get_action_keys(env::SokobanDirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::SokobanDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::SokobanDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)\nlevel_number = $(env.env.level_number)"
     print(io, str)
     return nothing

--- a/src/envs/sokoban/sokoban_undirected.jl
+++ b/src/envs/sokoban/sokoban_undirected.jl
@@ -197,7 +197,7 @@ CHARACTERS = ('☻', '█', '▒', '✖', '⋅')
 GW.get_height(env::SokobanUndirected) = size(env.tile_map, 2)
 GW.get_width(env::SokobanUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::SokobanUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::SokobanUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -210,7 +210,7 @@ GW.get_action_keys(env::SokobanUndirected) = ('w', 's', 'a', 'd')
 GW.get_action_names(env::SokobanUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
 
 function Base.show(io::IO, ::MIME"text/plain", env::SokobanUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)\nlevel_number = $(env.level_number)"
     print(io, str)
     return nothing

--- a/src/envs/sokoban/sokoban_undirected.jl
+++ b/src/envs/sokoban/sokoban_undirected.jl
@@ -194,8 +194,8 @@ end
 
 CHARACTERS = ('☻', '█', '▒', '✖', '⋅')
 
-GW.get_tile_map_height(env::SokobanUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::SokobanUndirected) = size(env.tile_map, 3)
+GW.get_height(env::SokobanUndirected) = size(env.tile_map, 2)
+GW.get_width(env::SokobanUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::SokobanUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/sokoban/sokoban_undirected.jl
+++ b/src/envs/sokoban/sokoban_undirected.jl
@@ -226,7 +226,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: SokobanUn
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: SokobanUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SokobanUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: SokobanUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: SokobanUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: SokobanUndirected} = env.env.reward

--- a/src/envs/sokoban/sokoban_undirected.jl
+++ b/src/envs/sokoban/sokoban_undirected.jl
@@ -192,29 +192,54 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '▒', '✖', '⋅')
-
 GW.get_height(env::SokobanUndirected) = size(env.tile_map, 2)
 GW.get_width(env::SokobanUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::SokobanUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::SokobanUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+GW.get_object_names(env::SokobanUndirected) = (:AGENT, :WALL, :BOX, :TARGET)
+
+function GW.get_pretty_tile_map(env::SokobanUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '▒', '✖', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::SokobanUndirected) = ('w', 's', 'a', 'd')
-GW.get_action_names(env::SokobanUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT)
+function GW.get_pretty_sub_tile_map(env::SokobanUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '▒', '✖', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::SokobanUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)\nlevel_number = $(env.level_number)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\nlevel_number: $(env.level_number)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::SokobanUndirected) = ('w', 's', 'a', 'd')
 
 #####
 ##### RLBase API

--- a/src/envs/sokoban/sokoban_undirected.jl
+++ b/src/envs/sokoban/sokoban_undirected.jl
@@ -60,7 +60,7 @@ howpublished= {https://github.com/deepmind/boxoban-levels/},
 year = "2018",
 }
 """
-mutable struct SokobanUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct SokobanUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/envs/transport_directed.jl
+++ b/src/envs/transport_directed.jl
@@ -36,7 +36,7 @@ function GW.reset!(env::TransportDirected)
 end
 
 function GW.act!(env::TransportDirected, action)
-    @assert action in 1:NUM_ACTIONS "Invalid action $(action)"
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action)"
 
     inner_env = env.env
     tile_map = inner_env.tile_map
@@ -119,7 +119,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: Transport
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: TransportDirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: TransportDirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: TransportDirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: TransportDirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: TransportDirected} = env.env.env.reward

--- a/src/envs/transport_directed.jl
+++ b/src/envs/transport_directed.jl
@@ -85,8 +85,8 @@ end
 
 CHARACTERS = ('☻', '█', '♦', '✖', '→', '↑', '←', '↓', '⋅')
 
-GW.get_tile_map_height(env::TransportDirected) = size(env.env.tile_map, 2)
-GW.get_tile_map_width(env::TransportDirected) = size(env.env.tile_map, 3)
+GW.get_height(env::TransportDirected) = size(env.env.tile_map, 2)
+GW.get_width(env::TransportDirected) = size(env.env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::TransportDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])

--- a/src/envs/transport_directed.jl
+++ b/src/envs/transport_directed.jl
@@ -88,7 +88,7 @@ CHARACTERS = ('☻', '█', '♦', '✖', '→', '↑', '←', '↓', '⋅')
 GW.get_height(env::TransportDirected) = size(env.env.tile_map, 2)
 GW.get_width(env::TransportDirected) = size(env.env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::TransportDirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::TransportDirected, i::Integer, j::Integer)
     object = findfirst(@view env.env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -103,7 +103,7 @@ GW.get_action_keys(env::TransportDirected) = ('w', 's', 'a', 'd', 'p', 'l')
 GW.get_action_names(env::TransportDirected) = (:MOVE_FORWARD, :MOVE_BACKWARD, :TURN_LEFT, :TURN_RIGHT, :PICK_UP, :DROP)
 
 function Base.show(io::IO, ::MIME"text/plain", env::TransportDirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.env.reward)\ndone = $(env.env.done)\nhas_gem = $(env.env.has_gem)"
     print(io, str)
     return nothing

--- a/src/envs/transport_directed.jl
+++ b/src/envs/transport_directed.jl
@@ -16,7 +16,7 @@ const GEM = TUM.GEM
 const TARGET = TUM.TARGET
 const NUM_ACTIONS = 6
 
-mutable struct TransportDirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct TransportDirected{R, RNG} <: GW.AbstractGridWorld
     env::TUM.TransportUndirected{R, RNG}
     agent_direction::Int
 end

--- a/src/envs/transport_undirected.jl
+++ b/src/envs/transport_undirected.jl
@@ -129,29 +129,54 @@ end
 ##### miscellaneous
 #####
 
-CHARACTERS = ('☻', '█', '♦', '✖', '⋅')
-
 GW.get_height(env::TransportUndirected) = size(env.tile_map, 2)
 GW.get_width(env::TransportUndirected) = size(env.tile_map, 3)
 
-function GW.get_pretty_tile_map(env::TransportUndirected, i::Integer, j::Integer)
-    object = findfirst(@view env.tile_map[:, i, j])
+GW.get_action_names(env::TransportUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT, :PICK_UP, :DROP)
+GW.get_object_names(env::TransportUndirected) = (:AGENT, :WALL, :GEM, :TARGET)
+
+function GW.get_pretty_tile_map(env::TransportUndirected, position::CartesianIndex{2})
+    characters = ('☻', '█', '♦', '✖', '⋅')
+
+    object = findfirst(@view env.tile_map[:, position])
     if isnothing(object)
-        return CHARACTERS[end]
+        return characters[end]
     else
-        return CHARACTERS[object]
+        return characters[object]
     end
 end
 
-GW.get_action_keys(env::TransportUndirected) = ('w', 's', 'a', 'd', 'p', 'l')
-GW.get_action_names(env::TransportUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT, :PICK_UP, :DROP)
+function GW.get_pretty_sub_tile_map(env::TransportUndirected, window_size, position::CartesianIndex{2})
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    characters = ('☻', '█', '♦', '✖', '⋅')
+
+    sub_tile_map = GW.get_sub_tile_map(tile_map, agent_position, window_size)
+
+    object = findfirst(@view sub_tile_map[:, position])
+    if isnothing(object)
+        return characters[end]
+    else
+        return characters[object]
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", env::TransportUndirected)
-    str = GW.get_pretty_tile_map(env)
-    str = str * "\nreward = $(env.reward)\ndone = $(env.done)\nhas_gem = $(env.has_gem)"
+    str = "tile_map:\n"
+    str = str * GW.get_pretty_tile_map(env)
+    str = str * "\nsub_tile_map:\n"
+    str = str * GW.get_pretty_sub_tile_map(env, GW.get_window_size(env))
+    str = str * "\nreward: $(env.reward)"
+    str = str * "\ndone: $(env.done)"
+    str = str * "\nhas_gem: $(env.has_gem)"
+    str = str * "\naction_names: $(GW.get_action_names(env))"
+    str = str * "\nobject_names: $(GW.get_object_names(env))"
     print(io, str)
     return nothing
 end
+
+GW.get_action_keys(env::TransportUndirected) = ('w', 's', 'a', 'd', 'p', 'l')
 
 #####
 ##### RLBase API

--- a/src/envs/transport_undirected.jl
+++ b/src/envs/transport_undirected.jl
@@ -83,7 +83,7 @@ function GW.reset!(env::TransportUndirected)
 end
 
 function GW.act!(env::TransportUndirected, action)
-    @assert action in 1:NUM_ACTIONS "Invalid action $(action)"
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action)"
 
     tile_map = env.tile_map
 
@@ -163,7 +163,7 @@ RLBase.state(env::GW.RLBaseEnv{E}, ::RLBase.InternalState) where {E <: Transport
 
 RLBase.reset!(env::GW.RLBaseEnv{E}) where {E <: TransportUndirected} = GW.reset!(env.env)
 
-RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: TransportUndirected} = 1:NUM_ACTIONS
+RLBase.action_space(env::GW.RLBaseEnv{E}) where {E <: TransportUndirected} = Base.OneTo(NUM_ACTIONS)
 (env::GW.RLBaseEnv{E})(action) where {E <: TransportUndirected} = GW.act!(env.env, action)
 
 RLBase.reward(env::GW.RLBaseEnv{E}) where {E <: TransportUndirected} = env.env.reward

--- a/src/envs/transport_undirected.jl
+++ b/src/envs/transport_undirected.jl
@@ -134,7 +134,7 @@ CHARACTERS = ('☻', '█', '♦', '✖', '⋅')
 GW.get_height(env::TransportUndirected) = size(env.tile_map, 2)
 GW.get_width(env::TransportUndirected) = size(env.tile_map, 3)
 
-function GW.get_tile_pretty_repr(env::TransportUndirected, i::Integer, j::Integer)
+function GW.get_pretty_tile_map(env::TransportUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])
     if isnothing(object)
         return CHARACTERS[end]
@@ -147,7 +147,7 @@ GW.get_action_keys(env::TransportUndirected) = ('w', 's', 'a', 'd', 'p', 'l')
 GW.get_action_names(env::TransportUndirected) = (:MOVE_UP, :MOVE_DOWN, :MOVE_LEFT, :MOVE_RIGHT, :PICK_UP, :DROP)
 
 function Base.show(io::IO, ::MIME"text/plain", env::TransportUndirected)
-    str = GW.get_tile_map_pretty_repr(env)
+    str = GW.get_pretty_tile_map(env)
     str = str * "\nreward = $(env.reward)\ndone = $(env.done)\nhas_gem = $(env.has_gem)"
     print(io, str)
     return nothing

--- a/src/envs/transport_undirected.jl
+++ b/src/envs/transport_undirected.jl
@@ -131,8 +131,8 @@ end
 
 CHARACTERS = ('☻', '█', '♦', '✖', '⋅')
 
-GW.get_tile_map_height(env::TransportUndirected) = size(env.tile_map, 2)
-GW.get_tile_map_width(env::TransportUndirected) = size(env.tile_map, 3)
+GW.get_height(env::TransportUndirected) = size(env.tile_map, 2)
+GW.get_width(env::TransportUndirected) = size(env.tile_map, 3)
 
 function GW.get_tile_pretty_repr(env::TransportUndirected, i::Integer, j::Integer)
     object = findfirst(@view env.tile_map[:, i, j])

--- a/src/envs/transport_undirected.jl
+++ b/src/envs/transport_undirected.jl
@@ -15,7 +15,7 @@ const GEM = 3
 const TARGET = 4
 const NUM_ACTIONS = 6
 
-mutable struct TransportUndirected{R, RNG} <: GW.AbstractGridWorldGame
+mutable struct TransportUndirected{R, RNG} <: GW.AbstractGridWorld
     tile_map::BitArray{3}
     agent_position::CartesianIndex{2}
     reward::R

--- a/src/play.jl
+++ b/src/play.jl
@@ -78,7 +78,7 @@ end
 
 replay(file_name; frame_rate = nothing) = replay(REPL.TerminalMenus.terminal, file_name, frame_rate = frame_rate)
 
-function play!(terminal::REPL.Terminals.UnixTerminal, env::GW.AbstractGridWorldGame; file_name::Union{Nothing, AbstractString} = nothing)
+function play!(terminal::REPL.Terminals.UnixTerminal, env::GW.AbstractGridWorld; file_name::Union{Nothing, AbstractString} = nothing)
     REPL.Terminals.raw!(terminal, true)
 
     terminal_out = terminal.out_stream
@@ -123,6 +123,6 @@ function play!(terminal::REPL.Terminals.UnixTerminal, env::GW.AbstractGridWorldG
     return nothing
 end
 
-play!(env::GW.AbstractGridWorldGame; file_name = nothing) = play!(REPL.TerminalMenus.terminal, env, file_name = file_name)
+play!(env::GW.AbstractGridWorld; file_name = nothing) = play!(REPL.TerminalMenus.terminal, env, file_name = file_name)
 
 end # module

--- a/src/rlbase.jl
+++ b/src/rlbase.jl
@@ -2,7 +2,7 @@ struct RLBaseEnv{E} <: RLBase.AbstractEnv
     env::E
 end
 
-Base.show(io::IO, mime::MIME"text/plain", env::RLBaseEnv{E}) where {E <: AbstractGridWorldGame} = show(io, mime, env.env)
-Play.play!(terminal::REPL.Terminals.UnixTerminal, env::RLBaseEnv{E}; file_name::Union{Nothing, AbstractString} = nothing) where {E <: AbstractGridWorldGame} = Play.play!(terminal, env.env, file_name = file_name)
-Play.play!(env::RLBaseEnv{E}; file_name = nothing) where {E <: AbstractGridWorldGame} = Play.play!(REPL.TerminalMenus.terminal, env.env, file_name = file_name)
-get_action_names(env::RLBaseEnv{E}) where {E <: AbstractGridWorldGame} = get_action_names(env.env)
+Base.show(io::IO, mime::MIME"text/plain", env::RLBaseEnv{E}) where {E <: AbstractGridWorld} = show(io, mime, env.env)
+Play.play!(terminal::REPL.Terminals.UnixTerminal, env::RLBaseEnv{E}; file_name::Union{Nothing, AbstractString} = nothing) where {E <: AbstractGridWorld} = Play.play!(terminal, env.env, file_name = file_name)
+Play.play!(env::RLBaseEnv{E}; file_name = nothing) where {E <: AbstractGridWorld} = Play.play!(REPL.TerminalMenus.terminal, env.env, file_name = file_name)
+get_action_names(env::RLBaseEnv{E}) where {E <: AbstractGridWorld} = get_action_names(env.env)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,7 +57,7 @@ function is_valid_terminal_return(env::GW.RLBaseEnv{E}, terminal_return) where {
     end
 end
 
-Test.@testset "AbstractGridWorldGame" begin
+Test.@testset "GridWorlds.jl" begin
     for Env in GW.ENVS
         Test.@testset "$(Env)" begin
             R = Float32


### PR DESCRIPTION
1. Update `RLBase.action_space` to return `Base.OneTo(NUM_ACTIONS)` for all environments. All environments have discrete action spaces and this is a consistent way to refer to them.
1. Rename `AbstractGridWorldGame` to `AbstractGridWorld`.
1. Rename `get_tile_map_height` to `get_height` and `get_tile_map_width` to `get_width`.
1. Rename `get_tile_pretty_repr` and `get_tile_map_pretty_repr` to `get_pretty_tile_map`.
1. Rename `get_sub_tile_pretty_repr` and `get_sub_tile_map_pretty_repr` to `get_pretty_sub_tile_map`.
1. Update the miscellaneous section for all environments. Use `CartesianIndex` as argument instead of passing `i` and `j` separately to `get_pretty_tile_map`. Add method `get_object_names` and print it along with `action_names` in the `show` method. Add `sub_tile_map` view to almost all environments.
1. Fix `benchmarks.jl`. Remove `RLBaseEnvModule`.
1. Update README.