### PR TITLE
revamp playing and replaying

### DIFF
--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -28,7 +28,7 @@ function benchmark(Env, num_resets, steps_per_reset)
     benchmark[:reset] = BT.@benchmark RLBase.reset!($(Ref(env))[])
     benchmark[:state] = BT.@benchmark RLBase.state($(Ref(env))[])
 
-    action_names = GW.get_action_names(env)
+    action_names = GW.get_action_names(env.env)
 
     for action in RLBase.action_space(env)
         benchmark[action_names[action]] = BT.@benchmark $(Ref(env))[]($(Ref(action))[])

--- a/src/play.jl
+++ b/src/play.jl
@@ -1,8 +1,3 @@
-module Play
-
-import ..GridWorlds as GW
-import REPL
-
 const ESC = Char(0x1B)
 const HIDE_CURSOR = ESC * "[?25l"
 const SHOW_CURSOR = ESC * "[?25h"
@@ -26,6 +21,7 @@ show_maybe(io::Nothing, mime::MIME, content) = nothing
 function show_io1_maybe_io2(io1::IO, io2::Union{Nothing, IO}, mime::MIME, content)
     show(io1, mime, content)
     show_maybe(io2, mime, content)
+    return nothing
 end
 
 function replay(terminal::REPL.Terminals.UnixTerminal, file_name::AbstractString; frame_rate = Union{Nothing, Real} = nothing)
@@ -78,19 +74,19 @@ end
 
 replay(file_name; frame_rate = nothing) = replay(REPL.TerminalMenus.terminal, file_name, frame_rate = frame_rate)
 
-function play!(terminal::REPL.Terminals.UnixTerminal, env::GW.AbstractGridWorld; file_name::Union{Nothing, AbstractString} = nothing)
+function play!(terminal::REPL.Terminals.UnixTerminal, env::AbstractGridWorld; file_name::Union{Nothing, AbstractString} = nothing)
     REPL.Terminals.raw!(terminal, true)
 
     terminal_out = terminal.out_stream
     terminal_in = terminal.in_stream
-    file = Play.open_maybe(file_name)
+    file = open_maybe(file_name)
 
     write_io1_maybe_io2(terminal_out, file, CLEAR_SCREEN)
     write_io1_maybe_io2(terminal_out, file, MOVE_CURSOR_TO_ORIGIN)
     write_io1_maybe_io2(terminal_out, file, HIDE_CURSOR)
 
-    action_keys = GW.get_action_keys(env)
-    action_names = GW.get_action_names(env)
+    action_keys = get_action_keys(env)
+    action_names = get_action_names(env)
     key_bindings = "play key bindings: 'q': quit, 'r': reset!, $(action_keys): $(action_names)\n"
 
     try
@@ -106,9 +102,9 @@ function play!(terminal::REPL.Terminals.UnixTerminal, env::GW.AbstractGridWorld;
                 REPL.Terminals.raw!(terminal, false)
                 return nothing
             elseif char == 'r'
-                GW.reset!(env)
+                reset!(env)
             elseif char in action_keys
-                GW.act!(env, findfirst(==(char), action_keys))
+                act!(env, findfirst(==(char), action_keys))
             end
 
             write_io1_maybe_io2(terminal_out, file, EMPTY_SCREEN)
@@ -123,6 +119,4 @@ function play!(terminal::REPL.Terminals.UnixTerminal, env::GW.AbstractGridWorld;
     return nothing
 end
 
-play!(env::GW.AbstractGridWorld; file_name = nothing) = play!(REPL.TerminalMenus.terminal, env, file_name = file_name)
-
-end # module
+play!(env::AbstractGridWorld; file_name = nothing) = play!(REPL.TerminalMenus.terminal, env, file_name = file_name)

--- a/src/rlbase.jl
+++ b/src/rlbase.jl
@@ -3,6 +3,6 @@ struct RLBaseEnv{E} <: RLBase.AbstractEnv
 end
 
 Base.show(io::IO, mime::MIME"text/plain", env::RLBaseEnv{E}) where {E <: AbstractGridWorld} = show(io, mime, env.env)
+
 play!(terminal::REPL.Terminals.UnixTerminal, env::RLBaseEnv{E}; file_name::Union{Nothing, AbstractString} = nothing) where {E <: AbstractGridWorld} = play!(terminal, env.env, file_name = file_name)
 play!(env::RLBaseEnv{E}; file_name = nothing) where {E <: AbstractGridWorld} = play!(REPL.TerminalMenus.terminal, env.env, file_name = file_name)
-get_action_names(env::RLBaseEnv{E}) where {E <: AbstractGridWorld} = get_action_names(env.env)

--- a/src/rlbase.jl
+++ b/src/rlbase.jl
@@ -4,5 +4,5 @@ end
 
 Base.show(io::IO, mime::MIME"text/plain", env::RLBaseEnv{E}) where {E <: AbstractGridWorld} = show(io, mime, env.env)
 
-play!(terminal::REPL.Terminals.UnixTerminal, env::RLBaseEnv{E}; file_name::Union{Nothing, AbstractString} = nothing) where {E <: AbstractGridWorld} = play!(terminal, env.env, file_name = file_name)
-play!(env::RLBaseEnv{E}; file_name = nothing) where {E <: AbstractGridWorld} = play!(REPL.TerminalMenus.terminal, env.env, file_name = file_name)
+play!(terminal::REPL.Terminals.UnixTerminal, env::RLBaseEnv{E}, file_name::Union{Nothing, AbstractString}, frame_start_delimiter::Union{Nothing, AbstractString}) where {E <: AbstractGridWorld} = play!(terminal, env.env, file_name, frame_start_delimiter)
+play!(env::RLBaseEnv{E}; file_name = nothing, frame_start_delimiter = nothing) where {E <: AbstractGridWorld} = play!(REPL.TerminalMenus.terminal, env.env, file_name, frame_start_delimiter)

--- a/src/rlbase.jl
+++ b/src/rlbase.jl
@@ -3,6 +3,6 @@ struct RLBaseEnv{E} <: RLBase.AbstractEnv
 end
 
 Base.show(io::IO, mime::MIME"text/plain", env::RLBaseEnv{E}) where {E <: AbstractGridWorld} = show(io, mime, env.env)
-Play.play!(terminal::REPL.Terminals.UnixTerminal, env::RLBaseEnv{E}; file_name::Union{Nothing, AbstractString} = nothing) where {E <: AbstractGridWorld} = Play.play!(terminal, env.env, file_name = file_name)
-Play.play!(env::RLBaseEnv{E}; file_name = nothing) where {E <: AbstractGridWorld} = Play.play!(REPL.TerminalMenus.terminal, env.env, file_name = file_name)
+play!(terminal::REPL.Terminals.UnixTerminal, env::RLBaseEnv{E}; file_name::Union{Nothing, AbstractString} = nothing) where {E <: AbstractGridWorld} = play!(terminal, env.env, file_name = file_name)
+play!(env::RLBaseEnv{E}; file_name = nothing) where {E <: AbstractGridWorld} = play!(REPL.TerminalMenus.terminal, env.env, file_name = file_name)
 get_action_names(env::RLBaseEnv{E}) where {E <: AbstractGridWorld} = get_action_names(env.env)


### PR DESCRIPTION
1. Remove `Play` module and move all its contents into the `GridWorlds` module.
1. Remove hardcoded delimiters and simplify the format of the recording file.
1. Don't forward `get_action_names` for `RLBaseEnv` type. Only forward `show` and `play!` for now.