### PR TITLE
update act! for all envs & some bug fixes

### DIFF
--- a/src/envs/catcher.jl
+++ b/src/envs/catcher.jl
@@ -69,39 +69,41 @@ function GW.reset!(env::Catcher)
 end
 
 function GW.act!(env::Catcher, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
     rng = env.rng
     _, height, width = size(tile_map)
+    agent_position = env.agent_position
+    gem_position = env.gem_position
 
     if action == 1
-        if env.agent_position[2] == 1
-            new_agent_position = env.agent_position
+        if agent_position[2] == 1
+            new_agent_position = agent_position
         else
-            new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
+            new_agent_position = GW.move_left(agent_position)
         end
     elseif action == 2
-        if env.agent_position[2] == width
-            new_agent_position = env.agent_position
+        if agent_position[2] == width
+            new_agent_position = agent_position
         else
-            new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+            new_agent_position = GW.move_right(agent_position)
         end
-    elseif action == 3
-        new_agent_position = env.agent_position
     else
-        error("Invalid action $(action)")
+        new_agent_position = agent_position
     end
 
-    tile_map[AGENT, env.agent_position] = false
+    tile_map[AGENT, agent_position] = false
     env.agent_position = new_agent_position
     tile_map[AGENT, new_agent_position] = true
 
-    if env.gem_position[1] == height
+    if gem_position[1] == height
         new_gem_position = CartesianIndex(1, rand(rng, 1 : width))
     else
-        new_gem_position = CartesianIndex(GW.move_down(env.gem_position.I...))
+        new_gem_position = GW.move_down(gem_position)
     end
 
-    tile_map[GEM, env.gem_position] = false
+    tile_map[GEM, gem_position] = false
     env.gem_position = new_gem_position
     tile_map[GEM, new_gem_position] = true
 

--- a/src/envs/collect_gems_directed.jl
+++ b/src/envs/collect_gems_directed.jl
@@ -35,31 +35,29 @@ function GW.reset!(env::CollectGemsDirected)
 end
 
 function GW.act!(env::CollectGemsDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !tile_map[WALL, new_agent_position]
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !tile_map[WALL, new_agent_position]
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
-    elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
+    else
+        env.agent_direction = GW.turn_right(agent_direction)
     end
 
     inner_env.reward = zero(inner_env.reward)

--- a/src/envs/collect_gems_multi_agent_undirected.jl
+++ b/src/envs/collect_gems_multi_agent_undirected.jl
@@ -97,7 +97,7 @@ function GW.reset!(env::CollectGemsMultiAgentUndirected)
 end
 
 function GW.act!(env::CollectGemsMultiAgentUndirected, action)
-    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action)"
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
 
     tile_map = env.tile_map
     agent_positions = env.agent_positions
@@ -109,13 +109,13 @@ function GW.act!(env::CollectGemsMultiAgentUndirected, action)
     GEM = num_agents + 2
 
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
     else
-        new_agent_position = CartesianIndex(GW.move_right(agent_position.I...))
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !any(@view tile_map[1 : num_agents + 1, new_agent_position]) # assuming WALL = num_agents + 1

--- a/src/envs/collect_gems_undirected.jl
+++ b/src/envs/collect_gems_undirected.jl
@@ -85,20 +85,23 @@ function GW.reset!(env::CollectGemsUndirected)
 end
 
 function GW.act!(env::CollectGemsUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
+    agent_position = env.agent_position
 
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
+    else
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !tile_map[WALL, new_agent_position]
-        tile_map[AGENT, env.agent_position] = false
+        tile_map[AGENT, agent_position] = false
         env.agent_position = new_agent_position
         tile_map[AGENT, new_agent_position] = true
     end

--- a/src/envs/door_key_directed.jl
+++ b/src/envs/door_key_directed.jl
@@ -37,35 +37,33 @@ function GW.reset!(env::DoorKeyDirected)
 end
 
 function GW.act!(env::DoorKeyDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !(tile_map[DOOR, new_agent_position] || tile_map[WALL, new_agent_position]) || (tile_map[DOOR, new_agent_position] && inner_env.has_key)
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !(tile_map[DOOR, new_agent_position] || tile_map[WALL, new_agent_position]) || (tile_map[DOOR, new_agent_position] && inner_env.has_key)
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
     elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_right(agent_direction)
     else
-        if tile_map[KEY, inner_env.agent_position]
+        if tile_map[KEY, agent_position]
             inner_env.has_key = true
-            tile_map[KEY, inner_env.agent_position] = false
+            tile_map[KEY, agent_position] = false
         end
     end
 

--- a/src/envs/door_key_undirected.jl
+++ b/src/envs/door_key_undirected.jl
@@ -128,40 +128,31 @@ function GW.reset!(env::DoorKeyUndirected)
 end
 
 function GW.act!(env::DoorKeyUndirected, action)
-    tile_map = env.tile_map
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
 
-    if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
-        if !(tile_map[DOOR, new_agent_position] || tile_map[WALL, new_agent_position]) || (tile_map[DOOR, new_agent_position] && env.has_key)
-            tile_map[AGENT, env.agent_position] = false
-            env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    tile_map = env.tile_map
+    agent_position = env.agent_position
+
+    if action in Base.OneTo(4)
+        if action == 1
+            new_agent_position = GW.move_up(agent_position)
+        elseif action == 2
+            new_agent_position = GW.move_down(agent_position)
+        elseif action == 3
+            new_agent_position = GW.move_left(agent_position)
+        else
+            new_agent_position = GW.move_right(agent_position)
         end
-    elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+
         if !(tile_map[DOOR, new_agent_position] || tile_map[WALL, new_agent_position]) || (tile_map[DOOR, new_agent_position] && env.has_key)
-            tile_map[AGENT, env.agent_position] = false
-            env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
-        end
-    elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-        if !(tile_map[DOOR, new_agent_position] || tile_map[WALL, new_agent_position]) || (tile_map[DOOR, new_agent_position] && env.has_key)
-            tile_map[AGENT, env.agent_position] = false
-            env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
-        end
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
-        if !(tile_map[DOOR, new_agent_position] || tile_map[WALL, new_agent_position]) || (tile_map[DOOR, new_agent_position] && env.has_key)
-            tile_map[AGENT, env.agent_position] = false
+            tile_map[AGENT, agent_position] = false
             env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     else
-        if tile_map[KEY, env.agent_position]
+        if tile_map[KEY, agent_position]
             env.has_key = true
-            tile_map[KEY, env.agent_position] = false
+            tile_map[KEY, agent_position] = false
         end
     end
 

--- a/src/envs/dynamic_obstacles_directed.jl
+++ b/src/envs/dynamic_obstacles_directed.jl
@@ -36,32 +36,31 @@ function GW.reset!(env::DynamicObstaclesDirected)
 end
 
 function GW.act!(env::DynamicObstaclesDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
     DOUM.update_obstacles!(inner_env)
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !tile_map[WALL, new_agent_position]
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
+
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !tile_map[WALL, new_agent_position]
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
-    elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
+    else
+        env.agent_direction = GW.turn_right(agent_direction)
     end
 
     if tile_map[GOAL, inner_env.agent_position]

--- a/src/envs/dynamic_obstacles_undirected.jl
+++ b/src/envs/dynamic_obstacles_undirected.jl
@@ -93,21 +93,25 @@ function GW.reset!(env::DynamicObstaclesUndirected)
 end
 
 function GW.act!(env::DynamicObstaclesUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
     update_obstacles!(env)
 
+    agent_position = env.agent_position
+
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
+    else
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !tile_map[WALL, new_agent_position]
-        tile_map[AGENT, env.agent_position] = false
+        tile_map[AGENT, agent_position] = false
         env.agent_position = new_agent_position
         tile_map[AGENT, new_agent_position] = true
     end

--- a/src/envs/go_to_target_directed.jl
+++ b/src/envs/go_to_target_directed.jl
@@ -36,31 +36,29 @@ function GW.reset!(env::GoToTargetDirected)
 end
 
 function GW.act!(env::GoToTargetDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !tile_map[WALL, new_agent_position]
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !tile_map[WALL, new_agent_position]
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
-    elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
+    else
+        env.agent_direction = GW.turn_right(agent_direction)
     end
 
     agent_position = inner_env.agent_position

--- a/src/envs/go_to_target_undirected.jl
+++ b/src/envs/go_to_target_undirected.jl
@@ -88,20 +88,23 @@ function GW.reset!(env::GoToTargetUndirected)
 end
 
 function GW.act!(env::GoToTargetUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
+    agent_position = env.agent_position
 
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
+    else
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !tile_map[WALL, new_agent_position]
-        tile_map[AGENT, env.agent_position] = false
+        tile_map[AGENT, agent_position] = false
         env.agent_position = new_agent_position
         tile_map[AGENT, new_agent_position] = true
     end

--- a/src/envs/grid_rooms_directed.jl
+++ b/src/envs/grid_rooms_directed.jl
@@ -35,31 +35,29 @@ function GW.reset!(env::GridRoomsDirected)
 end
 
 function GW.act!(env::GridRoomsDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !tile_map[WALL, new_agent_position]
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !tile_map[WALL, new_agent_position]
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
-    elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
+    else
+        env.agent_direction = GW.turn_right(agent_direction)
     end
 
     if tile_map[GOAL, inner_env.agent_position]

--- a/src/envs/grid_rooms_undirected.jl
+++ b/src/envs/grid_rooms_undirected.jl
@@ -95,20 +95,23 @@ function GW.reset!(env::GridRoomsUndirected)
 end
 
 function GW.act!(env::GridRoomsUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
+    agent_position = env.agent_position
 
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
+    else
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !tile_map[WALL, new_agent_position]
-        tile_map[AGENT, env.agent_position] = false
+        tile_map[AGENT, agent_position] = false
         env.agent_position = new_agent_position
         tile_map[AGENT, new_agent_position] = true
     end

--- a/src/envs/maze_directed.jl
+++ b/src/envs/maze_directed.jl
@@ -35,31 +35,29 @@ function GW.reset!(env::MazeDirected)
 end
 
 function GW.act!(env::MazeDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !tile_map[WALL, new_agent_position]
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !tile_map[WALL, new_agent_position]
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
-    elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
+    else
+        env.agent_direction = GW.turn_right(agent_direction)
     end
 
     if tile_map[GOAL, inner_env.agent_position]

--- a/src/envs/maze_undirected.jl
+++ b/src/envs/maze_undirected.jl
@@ -85,20 +85,23 @@ function GW.reset!(env::MazeUndirected)
 end
 
 function GW.act!(env::MazeUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
+    agent_position = env.agent_position
 
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
+    else
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !tile_map[WALL, new_agent_position]
-        tile_map[AGENT, env.agent_position] = false
+        tile_map[AGENT, agent_position] = false
         env.agent_position = new_agent_position
         tile_map[AGENT, new_agent_position] = true
     end

--- a/src/envs/sequential_rooms_directed.jl
+++ b/src/envs/sequential_rooms_directed.jl
@@ -35,31 +35,29 @@ function GW.reset!(env::SequentialRoomsDirected)
 end
 
 function GW.act!(env::SequentialRoomsDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !tile_map[WALL, new_agent_position]
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !tile_map[WALL, new_agent_position]
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
-    elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
+    else
+        env.agent_direction = GW.turn_right(agent_direction)
     end
 
     if tile_map[GOAL, inner_env.agent_position]

--- a/src/envs/sequential_rooms_undirected.jl
+++ b/src/envs/sequential_rooms_undirected.jl
@@ -79,20 +79,23 @@ function GW.reset!(env::SequentialRoomsUndirected)
 end
 
 function GW.act!(env::SequentialRoomsUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
+    agent_position = env.agent_position
 
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
+    else
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !tile_map[WALL, new_agent_position]
-        tile_map[AGENT, env.agent_position] = false
+        tile_map[AGENT, agent_position] = false
         env.agent_position = new_agent_position
         tile_map[AGENT, new_agent_position] = true
     end

--- a/src/envs/single_room_directed.jl
+++ b/src/envs/single_room_directed.jl
@@ -35,31 +35,29 @@ function GW.reset!(env::SingleRoomDirected)
 end
 
 function GW.act!(env::SingleRoomDirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     inner_env = env.env
     tile_map = inner_env.tile_map
+    agent_position = inner_env.agent_position
+    agent_direction = env.agent_direction
 
-    if action == 1
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
-        if !tile_map[WALL, new_agent_position]
-            tile_map[AGENT, agent_position] = false
-            inner_env.agent_position = new_agent_position
-            tile_map[AGENT, new_agent_position] = true
+    if action in Base.OneTo(2)
+        if action == 1
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
+        else
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
-    elseif action == 2
-        agent_position = inner_env.agent_position
-        agent_direction = env.agent_direction
-        new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+
         if !tile_map[WALL, new_agent_position]
             tile_map[AGENT, agent_position] = false
             inner_env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
     elseif action == 3
-        env.agent_direction = GW.turn_left(env.agent_direction)
-    elseif action == 4
-        env.agent_direction = GW.turn_right(env.agent_direction)
+        env.agent_direction = GW.turn_left(agent_direction)
+    else
+        env.agent_direction = GW.turn_right(agent_direction)
     end
 
     if tile_map[GOAL, inner_env.agent_position]

--- a/src/envs/single_room_undirected.jl
+++ b/src/envs/single_room_undirected.jl
@@ -76,20 +76,23 @@ function GW.reset!(env::SingleRoomUndirected)
 end
 
 function GW.act!(env::SingleRoomUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
+    agent_position = env.agent_position
 
     if action == 1
-        new_agent_position = CartesianIndex(GW.move_up(env.agent_position.I...))
+        new_agent_position = GW.move_up(agent_position)
     elseif action == 2
-        new_agent_position = CartesianIndex(GW.move_down(env.agent_position.I...))
+        new_agent_position = GW.move_down(agent_position)
     elseif action == 3
-        new_agent_position = CartesianIndex(GW.move_left(env.agent_position.I...))
-    elseif action == 4
-        new_agent_position = CartesianIndex(GW.move_right(env.agent_position.I...))
+        new_agent_position = GW.move_left(agent_position)
+    else
+        new_agent_position = GW.move_right(agent_position)
     end
 
     if !tile_map[WALL, new_agent_position]
-        tile_map[AGENT, env.agent_position] = false
+        tile_map[AGENT, agent_position] = false
         env.agent_position = new_agent_position
         tile_map[AGENT, new_agent_position] = true
     end

--- a/src/envs/sokoban/sokoban_undirected.jl
+++ b/src/envs/sokoban/sokoban_undirected.jl
@@ -107,6 +107,8 @@ function GW.reset!(env::SokobanUndirected)
 end
 
 function GW.act!(env::SokobanUndirected, action)
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
+
     tile_map = env.tile_map
     box_positions = env.box_positions
     box_reward = env.box_reward
@@ -115,19 +117,17 @@ function GW.act!(env::SokobanUndirected, action)
     agent_position = env.agent_position
 
     if action == 1
-        dest = CartesianIndex(GW.move_up(agent_position.I...))
-        beyond_dest = CartesianIndex(GW.move_up(dest.I...))
+        dest = GW.move_up(agent_position)
+        beyond_dest = GW.move_up(dest)
     elseif action == 2
-        dest = CartesianIndex(GW.move_down(agent_position.I...))
-        beyond_dest = CartesianIndex(GW.move_down(dest.I...))
+        dest = GW.move_down(agent_position)
+        beyond_dest = GW.move_down(dest)
     elseif action == 3
-        dest = CartesianIndex(GW.move_left(agent_position.I...))
-        beyond_dest = CartesianIndex(GW.move_left(dest.I...))
-    elseif action == 4
-        dest = CartesianIndex(GW.move_right(agent_position.I...))
-        beyond_dest = CartesianIndex(GW.move_right(dest.I...))
+        dest = GW.move_left(agent_position)
+        beyond_dest = GW.move_left(dest)
     else
-        error("Invalid action $(action)")
+        dest = GW.move_right(agent_position)
+        beyond_dest = GW.move_right(dest)
     end
 
     if !tile_map[WALL, dest]
@@ -140,7 +140,7 @@ function GW.act!(env::SokobanUndirected, action)
                 tile_map[BOX, dest] = false
                 tile_map[BOX, beyond_dest] = true
 
-                box_idx = findfirst(pos -> pos == dest, box_positions)
+                box_idx = findfirst(==(dest), box_positions)
                 box_positions[box_idx] = beyond_dest
                 tile_map[AGENT, agent_position] = false
                 env.agent_position = dest

--- a/src/envs/transport_directed.jl
+++ b/src/envs/transport_directed.jl
@@ -36,18 +36,18 @@ function GW.reset!(env::TransportDirected)
 end
 
 function GW.act!(env::TransportDirected, action)
-    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action)"
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
 
     inner_env = env.env
     tile_map = inner_env.tile_map
     agent_position = inner_env.agent_position
     agent_direction = env.agent_direction
 
-    if action in 1:2
+    if action in Base.OneTo(2)
         if action == 1
-            new_agent_position = CartesianIndex(GW.move_forward(agent_direction, agent_position.I...))
+            new_agent_position = GW.move_forward(agent_position, agent_direction)
         else
-            new_agent_position = CartesianIndex(GW.move_backward(agent_direction, agent_position.I...))
+            new_agent_position = GW.move_backward(agent_position, agent_direction)
         end
 
         if !tile_map[WALL, new_agent_position]
@@ -59,13 +59,17 @@ function GW.act!(env::TransportDirected, action)
         env.agent_direction = GW.turn_left(agent_direction)
     elseif action == 4
         env.agent_direction = GW.turn_right(agent_direction)
-    elseif action == 5 && tile_map[GEM, agent_position]
-        tile_map[GEM, agent_position] = false
-        inner_env.has_gem = true
-    elseif action == 6 && inner_env.has_gem
-        inner_env.has_gem = false
-        inner_env.gem_position = agent_position
-        tile_map[GEM, agent_position] = true
+    elseif action == 5
+        if tile_map[GEM, agent_position]
+            tile_map[GEM, agent_position] = false
+            inner_env.has_gem = true
+        end
+    else
+        if inner_env.has_gem
+            inner_env.has_gem = false
+            inner_env.gem_position = agent_position
+            tile_map[GEM, agent_position] = true
+        end
     end
 
     if tile_map[GEM, inner_env.target_position]

--- a/src/envs/transport_undirected.jl
+++ b/src/envs/transport_undirected.jl
@@ -78,26 +78,26 @@ function GW.reset!(env::TransportUndirected)
 
     env.reward = zero(env.reward)
     env.done = false
+    env.has_gem = false
 
     return nothing
 end
 
 function GW.act!(env::TransportUndirected, action)
-    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action)"
+    @assert action in Base.OneTo(NUM_ACTIONS) "Invalid action $(action). Action must be in Base.OneTo($(NUM_ACTIONS))"
 
     tile_map = env.tile_map
-
     agent_position = env.agent_position
 
-    if action in 1:4
+    if action in Base.OneTo(4)
         if action == 1
-            new_agent_position = CartesianIndex(GW.move_up(agent_position.I...))
+            new_agent_position = GW.move_up(agent_position)
         elseif action == 2
-            new_agent_position = CartesianIndex(GW.move_down(agent_position.I...))
+            new_agent_position = GW.move_down(agent_position)
         elseif action == 3
-            new_agent_position = CartesianIndex(GW.move_left(agent_position.I...))
+            new_agent_position = GW.move_left(agent_position)
         else
-            new_agent_position = CartesianIndex(GW.move_right(agent_position.I...))
+            new_agent_position = GW.move_right(agent_position)
         end
 
         if !tile_map[WALL, new_agent_position]
@@ -105,13 +105,17 @@ function GW.act!(env::TransportUndirected, action)
             env.agent_position = new_agent_position
             tile_map[AGENT, new_agent_position] = true
         end
-    elseif action == 5 && tile_map[GEM, agent_position]
-        tile_map[GEM, agent_position] = false
-        env.has_gem = true
-    elseif action == 6 && env.has_gem
-        env.has_gem = false
-        env.gem_position = agent_position
-        tile_map[GEM, agent_position] = true
+    elseif action == 5
+        if tile_map[GEM, agent_position]
+            tile_map[GEM, agent_position] = false
+            env.has_gem = true
+        end
+    else
+        if env.has_gem
+            env.has_gem = false
+            env.gem_position = agent_position
+            tile_map[GEM, agent_position] = true
+        end
     end
 
     if tile_map[GEM, env.target_position]

--- a/src/navigation.jl
+++ b/src/navigation.jl
@@ -35,37 +35,3 @@ function move_backward(position::CartesianIndex{2}, direction::Integer)
         return move_left(position)
     end
 end
-
-move_up(i::Integer, j::Integer) = (i - 1, j)
-move_down(i::Integer, j::Integer) = (i + 1, j)
-move_left(i::Integer, j::Integer) = (i, j - 1)
-move_right(i::Integer, j::Integer) = (i, j + 1)
-no_move(i::Integer, j::Integer) = (i, j)
-
-function move_forward(dir::Integer, i::Integer, j::Integer)
-    if dir == UP
-        return move_up(i, j)
-    elseif dir == DOWN
-        return move_down(i, j)
-    elseif dir == LEFT
-        return move_left(i, j)
-    elseif dir == RIGHT
-        return move_right(i, j)
-    else
-        return no_move(i, j)
-    end
-end
-
-function move_backward(dir::Integer, i::Integer, j::Integer)
-    if dir == UP
-        return move_down(i, j)
-    elseif dir == DOWN
-        return move_up(i, j)
-    elseif dir == LEFT
-        return move_right(i, j)
-    elseif dir == RIGHT
-        return move_left(i, j)
-    else
-        return no_move(i, j)
-    end
-end

--- a/src/navigation.jl
+++ b/src/navigation.jl
@@ -4,8 +4,37 @@ const UP = 1
 const LEFT = 2
 const DOWN = 3
 
-turn_left(dir::Integer) = mod(dir + 1, NUM_DIRECTIONS)
-turn_right(dir::Integer) = mod(dir - 1, NUM_DIRECTIONS)
+turn_left(direction::Integer) = mod(direction + 1, NUM_DIRECTIONS)
+turn_right(direction::Integer) = mod(direction - 1, NUM_DIRECTIONS)
+
+move_up(position::CartesianIndex{2}) = CartesianIndex(position[1] - 1, position[2])
+move_down(position::CartesianIndex{2}) = CartesianIndex(position[1] + 1, position[2])
+move_left(position::CartesianIndex{2}) = CartesianIndex(position[1], position[2] - 1)
+move_right(position::CartesianIndex{2}) = CartesianIndex(position[1], position[2] + 1)
+
+function move_forward(position::CartesianIndex{2}, direction::Integer)
+    if direction == UP
+        return move_up(position)
+    elseif direction == DOWN
+        return move_down(position)
+    elseif direction == LEFT
+        return move_left(position)
+    else direction == RIGHT
+        return move_right(position)
+    end
+end
+
+function move_backward(position::CartesianIndex{2}, direction::Integer)
+    if direction == UP
+        return move_down(position)
+    elseif direction == DOWN
+        return move_up(position)
+    elseif direction == LEFT
+        return move_right(position)
+    else direction == RIGHT
+        return move_left(position)
+    end
+end
 
 move_up(i::Integer, j::Integer) = (i - 1, j)
 move_down(i::Integer, j::Integer) = (i + 1, j)


### PR DESCRIPTION
1. Change the `move_*` methods to take `CartesianIndex{2}` arguments.
1. Update `act!` methods for all environments. Check if `action` argument is a valid action. Simplify and use new `move_*` methods.
1. Fix `get_pretty_tile_map` method in `SokobanDirected`.
1. Fix buggy `reset!` behavior in `TransportUndirected`.