### PR TITLE
revisiting interactivity: bug fixes and quality of life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ GW.play!(env)
 
 # play and record the interaction in a file called recording.txt
 
-GW.play!(env, file_name = "recording.txt", frame_start_delimiter = "FRAME_START_DELIMITER")
+GW.play!(env, file_name = "recording.txt")
 
 # manually step through the frames in the recording
 
-GW.replay(file_name = "recording.txt", frame_start_delimiter = "FRAME_START_DELIMITER")
+GW.replay(file_name = "recording.txt")
 
 # replay the recording inside the terminal at a given frame rate
 
-GW.replay(file_name = "recording.txt", frame_start_delimiter = "FRAME_START_DELIMITER", frame_rate = 2)
+GW.replay(file_name = "recording.txt", frame_rate = 2)
 
 # use the RLBase API
 
@@ -161,13 +161,14 @@ import ReinforcementLearningBase as RLBase
 
 game = GW.SingleRoomUndirectedModule.SingleRoomUndirected()
 env = GW.RLBaseEnv(game)
+frame_start_delimiter = "SOME_FRAME_START_DELIMITER"
 
 total_reward = zero(RLBase.reward(env))
 frame_number = 1
 
 str = ""
 
-str = str * "FRAME_START_DELIMITER"
+str = str * frame_start_delimiter
 str = str * "frame_number: $(frame_number)\n"
 str = str * repr(MIME"text/plain"(), env)
 str = str * "\ntotal_reward: $(total_reward)"
@@ -180,7 +181,7 @@ while !RLBase.is_terminated(env)
     global total_reward += reward
     global frame_number += 1
 
-    global str = str * "FRAME_START_DELIMITER"
+    global str = str * frame_start_delimiter
     global str = str * "frame_number: $(frame_number)\n"
     global str = str * repr(MIME"text/plain"(), env)
     global str = str * "\ntotal_reward: $(total_reward)"
@@ -188,7 +189,7 @@ end
 
 write("recording.txt", str)
 
-GW.replay(file_name = "recording.txt", frame_start_delimiter = "FRAME_START_DELIMITER")
+GW.replay(file_name = "recording.txt", frame_start_delimiter = frame_start_delimiter)
 ```
 
 In `ReinforcementLearning.jl`, you can create a [hook](https://juliareinforcementlearning.org/docs/How_to_use_hooks/) for recording the agent's behavior at any point during training.

--- a/src/play.jl
+++ b/src/play.jl
@@ -22,7 +22,6 @@ close_maybe(io::Nothing) = nothing
 
 write_maybe(io::IO, content) = write(io, content)
 write_maybe(io::Nothing, content) = 0
-write_maybe(io1, io2, content) = write_maybe(io1, content) + write_maybe(io2, content)
 
 function play!(terminal::REPL.Terminals.UnixTerminal, env::AbstractGridWorld, file_name::Union{Nothing, AbstractString}, frame_start_delimiter::AbstractString)
     terminal_out = terminal.out_stream
@@ -48,7 +47,8 @@ function play!(terminal::REPL.Terminals.UnixTerminal, env::AbstractGridWorld, fi
             frame = frame * "\n" * "Last play character read: $(char)"
             frame = frame * "\n" * repr(MIME"text/plain"(), env)
 
-            write_maybe(terminal_out, file, frame)
+            write_maybe(terminal_out, frame)
+            write_maybe(file, frame)
 
             char = read(terminal_in, Char)
 

--- a/src/play.jl
+++ b/src/play.jl
@@ -69,7 +69,7 @@ end
 
 play!(env::AbstractGridWorld; file_name = nothing, frame_start_delimiter = DEFAULT_FRAME_START_DELIMITER) = play!(REPL.TerminalMenus.terminal, env, file_name, frame_start_delimiter)
 
-function replay(terminal::REPL.Terminals.UnixTerminal, file_name::AbstractString, frame_start_delimiter::AbstractString, frame_rate = Union{Nothing, Real})
+function replay(terminal::REPL.Terminals.UnixTerminal, file_name::AbstractString, frame_start_delimiter::AbstractString, frame_rate::Union{Nothing, Real})
     terminal_out = terminal.out_stream
     strings = split(read(file_name, String), frame_start_delimiter)
     frames = @view strings[2:end]

--- a/src/play.jl
+++ b/src/play.jl
@@ -7,7 +7,14 @@ const CLEAR_SCREEN_BEFORE_CURSOR = ESC * "[1J"
 const EMPTY_SCREEN = CLEAR_SCREEN_BEFORE_CURSOR * MOVE_CURSOR_TO_ORIGIN
 const DEFAULT_FRAME_START_DELIMITER = "FRAME_START_DELIMITER"
 
-open_maybe(file_name::AbstractString) = open(file_name, "w")
+function open_maybe(file_name::AbstractString)
+    if isfile(file_name)
+        error("File $(file_name) already exists!")
+    else
+        open(file_name, "w")
+    end
+end
+
 open_maybe(::Nothing) = nothing
 
 close_maybe(io::IO) = close(io)

--- a/src/play.jl
+++ b/src/play.jl
@@ -5,6 +5,7 @@ const CLEAR_SCREEN = ESC * "[2J"
 const MOVE_CURSOR_TO_ORIGIN = ESC * "[H"
 const CLEAR_SCREEN_BEFORE_CURSOR = ESC * "[1J"
 const EMPTY_SCREEN = CLEAR_SCREEN_BEFORE_CURSOR * MOVE_CURSOR_TO_ORIGIN
+const DEFAULT_FRAME_START_DELIMITER = "FRAME_START_DELIMITER"
 
 open_maybe(file_name::AbstractString) = open(file_name, "w")
 open_maybe(::Nothing) = nothing
@@ -16,14 +17,7 @@ write_maybe(io::IO, content) = write(io, content)
 write_maybe(io::Nothing, content) = 0
 write_maybe(io1, io2, content) = write_maybe(io1, content) + write_maybe(io2, content)
 
-function play!(terminal::REPL.Terminals.UnixTerminal, env::AbstractGridWorld, file_name::Union{Nothing, AbstractString}, frame_start_delimiter::Union{Nothing, AbstractString})
-    if !isnothing(file_name) && isnothing(frame_start_delimiter)
-        error("Please additionally specify a string for the keyword argument `frame_start_delimiter`, for example `frame_start_delimiter = \"FRAME_START_DELIMITER\"`. This is needed when you want to replay the recording.")
-    end
-    if isnothing(file_name) && !isnothing(frame_start_delimiter)
-        error("Please additionally specify a string for the keyword argument `file_name`, for example `file_name = \"recording.txt\"`. This is needed to save the recording in a text file and replay it later.")
-    end
-
+function play!(terminal::REPL.Terminals.UnixTerminal, env::AbstractGridWorld, file_name::Union{Nothing, AbstractString}, frame_start_delimiter::AbstractString)
     terminal_out = terminal.out_stream
     terminal_in = terminal.in_stream
     file = open_maybe(file_name)
@@ -73,7 +67,7 @@ function play!(terminal::REPL.Terminals.UnixTerminal, env::AbstractGridWorld, fi
     return nothing
 end
 
-play!(env::AbstractGridWorld; file_name = nothing, frame_start_delimiter = nothing) = play!(REPL.TerminalMenus.terminal, env, file_name, frame_start_delimiter)
+play!(env::AbstractGridWorld; file_name = nothing, frame_start_delimiter = DEFAULT_FRAME_START_DELIMITER) = play!(REPL.TerminalMenus.terminal, env, file_name, frame_start_delimiter)
 
 function replay(terminal::REPL.Terminals.UnixTerminal, file_name::AbstractString, frame_start_delimiter::AbstractString, frame_rate = Union{Nothing, Real})
     terminal_out = terminal.out_stream
@@ -139,4 +133,4 @@ function replay(terminal::REPL.Terminals.UnixTerminal, file_name::AbstractString
     end
 end
 
-replay(; file_name, frame_start_delimiter, frame_rate = nothing) = replay(REPL.TerminalMenus.terminal, file_name, frame_start_delimiter, frame_rate)
+replay(; file_name, frame_start_delimiter = DEFAULT_FRAME_START_DELIMITER, frame_rate = nothing) = replay(REPL.TerminalMenus.terminal, file_name, frame_start_delimiter, frame_rate)

--- a/src/play.jl
+++ b/src/play.jl
@@ -91,6 +91,7 @@ function replay(terminal::REPL.Terminals.UnixTerminal, file_name::AbstractString
             while true
                 replay_frame = replay_key_bindings
                 replay_frame = replay_frame * "\n" * "Last replay character read: $(char)"
+                replay_frame = replay_frame * "\n" * "frame number: $(current_frame)/$(num_frames)"
                 replay_frame = replay_frame * "\n" * "------------FRAME_START------------"
                 replay_frame = replay_frame * "\n" * frames[current_frame]
 


### PR DESCRIPTION
1. Fix type signature of frame_rate in replay method
2. Add default value for `frame_start_delimiter`
3. Prevent accidental overwrite of recording file
4. Print frame number during replay